### PR TITLE
Make initial panel use arrow and enter keys to activate items once the window has opened

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -206,8 +206,8 @@ LxQtConfig::MainWindow::MainWindow() : QMainWindow()
     view->setUniformItemSizes(true);
     view->setCategoryDrawer(new QCategoryDrawerV3(view));
 
-    connect(view, SIGNAL(activated(const QModelIndex&)),
-            this, SLOT(activateItem(const QModelIndex&)));
+    connect(view, SIGNAL(activated(const QModelIndex&)), SLOT(activateItem(const QModelIndex&)));
+    view->setFocus();
 
     QTimer::singleShot(1, this, SLOT(load()));
 }
@@ -230,6 +230,7 @@ void LxQtConfig::MainWindow::activateItem(const QModelIndex &index)
 {
     if (!index.isValid())
         return;
+
     QModelIndex orig = proxyModel->mapToSource(index);
     model->activateItem(orig);
 }


### PR DESCRIPTION
~~Fixes lxde/lxde-qt#266, although in this PR PCManFM's click settings are not respected, just like KDE's System Settings does not respect Dolphin's. @agaida any comments on that?~~
