### PR TITLE
Autohint option and KDE compatibility

### DIFF
--- a/lxqt-config-appearance/fontconfigfile.cpp
+++ b/lxqt-config-appearance/fontconfigfile.cpp
@@ -37,6 +37,7 @@ FontConfigFile::FontConfigFile(QObject* parent):
     mSubpixel("rgb"),
     mHintStyle("hintslight"),
     mDpi(96),
+    mAutohint(false),
     mSaveTimer(NULL)
 {
     mDirPath = QString::fromLocal8Bit(qgetenv("XDG_CONFIG_HOME"));
@@ -89,6 +90,12 @@ void FontConfigFile::setDpi(int value)
     queueSave();
 }
 
+void FontConfigFile::setAutohint(bool value)
+{
+    mAutohint = value;
+    queueSave();
+}
+
 void FontConfigFile::load()
 {
     QFile file(mFilePath);
@@ -133,6 +140,11 @@ void FontConfigFile::load()
                     QString value = editElem.firstChildElement("double").text();
                     mDpi = value.toInt();
                 }
+                else if(name == "autohint")
+                {
+                    QString value = editElem.firstChildElement("bool").text();
+                    mAutohint = value[0] == 't' ? true : false;
+                }
             }
         }
         else // the config file is created by others => make a backup and write our config
@@ -171,17 +183,30 @@ void FontConfigFile::save()
         "    <edit name=\"antialias\" mode=\"assign\">\n"
         "      <bool>" << (mAntialias ? "true" : "false") << "</bool>\n"
         "    </edit>\n"
+        "  </match>\n"
+        "  <match target=\"font\">\n"
         "    <edit name=\"rgba\" mode=\"assign\">\n"
         "      <const>" << mSubpixel << "</const>\n"
         "    </edit>\n"
+        "  </match>\n"
+        "  <match target=\"font\">\n"
         "    <edit name=\"lcdfilter\" mode=\"assign\">\n"
         "      <const>lcddefault</const>\n"
         "    </edit>\n"
+        "  </match>\n"
+        "  <match target=\"font\">\n"
         "    <edit name=\"hinting\" mode=\"assign\">\n"
         "      <bool>" << (mHinting ? "true" : "false") << "</bool>\n"
         "    </edit>\n"
+        "  </match>\n"
+        "  <match target=\"font\">\n"
         "    <edit name=\"hintstyle\" mode=\"assign\">\n"
         "      <const>" << mHintStyle << "</const>\n"
+        "    </edit>\n"
+        "  </match>\n"
+        "  <match target=\"font\">\n"
+        "    <edit name=\"autohint\" mode=\"assign\">\n"
+        "      <bool>" << (mAutohint ? "true" : "false") << "</bool>\n"
         "    </edit>\n"
         "  </match>\n"
         "  <match target=\"pattern\">\n"

--- a/lxqt-config-appearance/fontconfigfile.h
+++ b/lxqt-config-appearance/fontconfigfile.h
@@ -59,6 +59,11 @@ public:
     }
     void setDpi(int value);
 
+    bool autohint() const {
+        return mAutohint;
+    }
+    void setAutohint(bool value);
+
 private Q_SLOTS:
     void save();
 
@@ -72,6 +77,7 @@ private:
     QByteArray mSubpixel;
     QByteArray mHintStyle;
     int mDpi;
+    bool mAutohint;
     QString mDirPath;
     QString mFilePath;
     QTimer* mSaveTimer;

--- a/lxqt-config-appearance/fontsconfig.cpp
+++ b/lxqt-config-appearance/fontsconfig.cpp
@@ -65,6 +65,7 @@ FontsConfig::FontsConfig(LxQt::Settings* settings, QSettings* qtSettings, QWidge
     connect(ui->hinting, SIGNAL(toggled(bool)), SLOT(hintingToggled(bool)));
     connect(ui->hintStyle, SIGNAL(currentIndexChanged(int)), SLOT(hintStyleChanged(int)));
     connect(ui->dpi, SIGNAL(valueChanged(int)), SLOT(dpiChanged(int)));
+    connect(ui->autohint, SIGNAL(toggled(bool)), SLOT(autohintToggled(bool)));
 }
 
 
@@ -95,6 +96,7 @@ void FontsConfig::initControls()
 
     // load fontconfig config
     ui->antialias->setChecked(mFontConfigFile.antialias());
+    ui->autohint->setChecked(mFontConfigFile.autohint());
 
     QByteArray subpixelStr = mFontConfigFile.subpixel();
     int subpixel;
@@ -147,6 +149,11 @@ void FontsConfig::subpixelChanged(int index)
 void FontsConfig::hintStyleChanged(int index)
 {
     mFontConfigFile.setHintStyle(hintStyleNames[index]);
+}
+
+void FontsConfig::autohintToggled(bool toggled)
+{
+    mFontConfigFile.setAutohint(toggled);
 }
 
 void FontsConfig::updateQtFont()

--- a/lxqt-config-appearance/fontsconfig.h
+++ b/lxqt-config-appearance/fontsconfig.h
@@ -58,6 +58,7 @@ private Q_SLOTS:
     void subpixelChanged(int index);
     void hintStyleChanged(int index);
     void dpiChanged(int value);
+    void autohintToggled(bool toggled);
 
 private:
     Ui::FontsConfig *ui;

--- a/lxqt-config-appearance/fontsconfig.ui
+++ b/lxqt-config-appearance/fontsconfig.ui
@@ -145,6 +145,13 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="autohint">
+        <property name="text">
+         <string>Autohint</string>
+        </property>
+       </widget>
+      </item>
       <item row="5" column="1">
        <widget class="QSpinBox" name="dpi">
         <property name="minimum">


### PR DESCRIPTION
- Add option autohint
- Fix compatibility with KDE fonts settings

https://github.com/lxde/lxde-qt/issues/262
