### PR TITLE
[RFC] Option to set single-click as default and sigle-click handling in system settings' main window

### DIFF
--- a/lxqt-config-input/mouseconfig.h
+++ b/lxqt-config-input/mouseconfig.h
@@ -50,6 +50,7 @@ private Q_SLOTS:
   void onMouseLeftHandedToggled(bool checked);
   void onDoubleClickIntervalChanged(int value);
   void onWheelScrollLinesChanged(int value);
+  void onSingleClickChanged(bool checked);
 
 private:
   Ui::MouseConfig ui;
@@ -61,6 +62,8 @@ private:
   int oldThreshold;
   bool leftHanded;
   bool oldLeftHanded;
+  bool singleClick;
+  bool oldSingleClick;
 };
 
 #endif // MOUSECONFIG_H

--- a/lxqt-config-input/mouseconfig.ui
+++ b/lxqt-config-input/mouseconfig.ui
@@ -154,10 +154,17 @@
    <item row="5" column="1">
     <widget class="QSpinBox" name="wheelScrollLines"/>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QCheckBox" name="mouseLeftHanded">
      <property name="text">
       <string>Left handed (Swap left and right mouse buttons)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="singleClick">
+     <property name="text">
+      <string>Single click to activate items</string>
      </property>
     </widget>
    </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -206,10 +206,33 @@ LxQtConfig::MainWindow::MainWindow() : QMainWindow()
     view->setUniformItemSizes(true);
     view->setCategoryDrawer(new QCategoryDrawerV3(view));
 
-    connect(view, SIGNAL(activated(const QModelIndex&)), SLOT(activateItem(const QModelIndex&)));
+    // Qt bug: signal activated should respect the hint, but it doesn't
+    if (style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick))
+        connect(view, SIGNAL(clicked(const QModelIndex&)), SLOT(activateItem(const QModelIndex&)));
+    else
+        connect(view, SIGNAL(doubleClicked(const QModelIndex&)), SLOT(activateItem(const QModelIndex&)));
     view->setFocus();
 
     QTimer::singleShot(1, this, SLOT(load()));
+}
+
+bool LxQtConfig::MainWindow::event(QEvent* event)
+{
+    if (event->type() == QEvent::ThemeChange)
+    {
+        // Qt bug: signal activated should respect the hint, but it doesn't
+        if (style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick))
+        {
+            view->disconnect(this);
+            connect(view, SIGNAL(clicked(const QModelIndex&)), SLOT(activateItem(const QModelIndex&)));
+        }
+        else
+        {
+            view->disconnect(this);
+            connect(view, SIGNAL(doubleClicked(const QModelIndex&)), SLOT(activateItem(const QModelIndex&)));
+        }
+    }
+    return QMainWindow::event(event);
 }
 
 void LxQtConfig::MainWindow::load()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -56,6 +56,7 @@ private:
 
 private:
     void builGroup(const QDomElement& xml);
+    bool event(QEvent *event);
 
 private slots:
     void load();


### PR DESCRIPTION
Fixes lxde/lxde-qt#266.

The single-click handing in System Settings' main window is a temporary fix until a more clean approach is found. See the discussion (lxde/lxde-qt#266). It might as well not be very clear that the option does not work for pcmanfm-qt, which has it's own configuration options.
