### PR TITLE
- Unify naming for a unique lxqt. No more suffixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Qt5Xml REQUIRED QUIET)
 find_package(Qt5Concurrent REQUIRED QUIET)
 find_package(Qt5X11Extras REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
-find_package(lxqt-qt5 REQUIRED QUIET)
+find_package(lxqt REQUIRED QUIET)
 find_package(qt5xdg REQUIRED)
 find_package(KF5WindowSystem REQUIRED QUIET)
 


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro helio@kde.org
