### PR TITLE
[WIP] Touchpad settings

### DIFF
--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -1,8 +1,11 @@
 project(lxqt-config-input)
 find_package(X11 REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(XORG_LIBINPUT REQUIRED xorg-libinput)
 
 include_directories(
     ${X11_INCLUDE_DIR}
+    ${XORG_LIBINPUT_INCLUDE_DIRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
 )
 

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -12,6 +12,7 @@ set(lxqt-config-input_HDRS
     mouseconfig.h
     keyboardlayoutconfig.h
     selectkeyboardlayoutdialog.h
+    touchpadconfig.h
 )
 
 set(lxqt-config-input_SRCS
@@ -20,6 +21,8 @@ set(lxqt-config-input_SRCS
     mouseconfig.cpp
     keyboardlayoutconfig.cpp
     selectkeyboardlayoutdialog.cpp
+    touchpadconfig.cpp
+    touchpaddevice.cpp
 )
 
 set(lxqt-config-input_UIS
@@ -27,6 +30,7 @@ set(lxqt-config-input_UIS
     keyboardconfig.ui
     keyboardlayoutconfig.ui
     selectkeyboardlayoutdialog.ui
+    touchpadconfig.ui
 )
 
 # Translations **********************************
@@ -61,8 +65,10 @@ target_link_libraries(lxqt-config-input
     Qt5::Widgets
     Qt5::X11Extras
     ${X11_LIBRARIES}
+    ${X11_Xinput_LIB}
     lxqt
     lxqt-config-cursor
+    udev
 )
 
 set_target_properties(lxqt-config-input

--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -26,6 +26,7 @@
 #include "../liblxqt-config-cursor/selectwnd.h"
 #include "keyboardlayoutconfig.h"
 #include "touchpadconfig.h"
+#include "touchpaddevice.h"
 
 int main(int argc, char** argv) {
     LXQt::SingleApplication app(argc, argv);
@@ -40,6 +41,9 @@ int main(int argc, char** argv) {
     app.setApplicationVersion(VERINFO);
 
     dlgOptions.setCommandLine(&parser);
+    QCommandLineOption loadOption("load-touchpad",
+            app.tr("Load last touchpad settings."));
+    parser.addOption(loadOption);
     parser.addVersionOption();
     parser.addHelpOption();
     parser.process(app);
@@ -49,6 +53,13 @@ int main(int argc, char** argv) {
     if(configName.isEmpty())
       configName = "session";
     LXQt::Settings settings(configName);
+
+    bool loadLastTouchpadSettings = parser.isSet(loadOption);
+    if (loadLastTouchpadSettings) {
+        TouchpadDevice::loadSettings(&settings);
+        return 0;
+    }
+
     LXQt::ConfigDialog dlg(QObject::tr("Keyboard and Mouse Settings"), &settings);
     app.setActivationWindow(&dlg);
 

--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -25,6 +25,7 @@
 #include "keyboardconfig.h"
 #include "../liblxqt-config-cursor/selectwnd.h"
 #include "keyboardlayoutconfig.h"
+#include "touchpadconfig.h"
 
 int main(int argc, char** argv) {
     LXQt::SingleApplication app(argc, argv);
@@ -67,6 +68,11 @@ int main(int argc, char** argv) {
     KeyboardLayoutConfig* keyboardLayoutConfig = new KeyboardLayoutConfig(&settings, &dlg);
     dlg.addPage(keyboardLayoutConfig, QObject::tr("Keyboard Layout"), "input-keyboard");
     QObject::connect(&dlg, SIGNAL(reset()), keyboardLayoutConfig, SLOT(reset()));
+
+    TouchpadConfig* touchpadConfig = new TouchpadConfig(&settings, &dlg);
+    dlg.addPage(touchpadConfig, QObject::tr("Touchpad"), "input-tablet");
+    QObject::connect(&dlg, &LXQt::ConfigDialog::reset,
+                     touchpadConfig, &TouchpadConfig::reset);
 
     dlg.setWindowIcon(QIcon::fromTheme("input-keyboard"));
 

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -19,6 +19,7 @@
 #include "touchpadconfig.h"
 #include "touchpaddevice.h"
 
+#include <cmath>
 #include <QUrl>
 #include <LXQt/AutostartEntry>
 #include <LXQt/Settings>
@@ -48,6 +49,8 @@ TouchpadConfig::TouchpadConfig(LXQt::Settings* _settings, QWidget* parent):
             this, &TouchpadConfig::setNaturalScrollingEnabled);
     connect(ui.tapToDragEnabledCheckBox, &QCheckBox::stateChanged,
             this, &TouchpadConfig::setTapToDragEnabled);
+    connect(ui.accelSpeedDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, [this] (double value) { setAccelSpeed(static_cast<float>(value)); });
     connect(ui.twoFingerScrollingRadioButton, &QRadioButton::toggled,
             this, &TouchpadConfig::scrollingRadioButtonToggled);
     connect(ui.edgeScrollingRadioButton, &QRadioButton::toggled,
@@ -83,6 +86,14 @@ void TouchpadConfig::initControls()
     initFeatureControl(ui.tappingEnabledCheckBox, device.tappingEnabled());
     initFeatureControl(ui.naturalScrollingEnabledCheckBox, device.naturalScrollingEnabled());
     initFeatureControl(ui.tapToDragEnabledCheckBox, device.tapToDragEnabled());
+
+    float accelSpeed = device.accelSpeed();
+    if (!std::isnan(accelSpeed)) {
+        ui.accelSpeedDoubleSpinBox->setEnabled(true);
+        ui.accelSpeedDoubleSpinBox->setValue(accelSpeed);
+    } else {
+        ui.accelSpeedDoubleSpinBox->setEnabled(false);
+    }
 
     int scrollMethodsAvailable = device.scrollMethodsAvailable();
     ui.twoFingerScrollingRadioButton->setEnabled(scrollMethodsAvailable & TWO_FINGER);
@@ -130,6 +141,7 @@ void TouchpadConfig::reset()
         device.setTappingEnabled(device.oldTappingEnabled());
         device.setNaturalScrollingEnabled(device.oldNaturalScrollingEnabled());
         device.setTapToDragEnabled(device.oldTapToDragEnabled());
+        device.setAccelSpeed(device.oldAccelSpeed());
         device.setScrollingMethodEnabled(device.oldScrollingMethodEnabled());
     }
     initControls();
@@ -151,6 +163,12 @@ void TouchpadConfig::setNaturalScrollingEnabled(int state)
 void TouchpadConfig::setTapToDragEnabled(int state)
 {
     devices[curDevice].setTapToDragEnabled(state == Qt::Checked);
+    accept();
+}
+
+void TouchpadConfig::setAccelSpeed(float speed)
+{
+    devices[curDevice].setAccelSpeed(speed);
     accept();
 }
 

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -1,0 +1,163 @@
+/*
+    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "touchpadconfig.h"
+#include "touchpaddevice.h"
+
+#include <QUrl>
+#include <LXQt/Settings>
+
+TouchpadConfig::TouchpadConfig(LXQt::Settings* _settings, QWidget* parent):
+    QWidget(parent),
+    settings(_settings),
+    curDevice(-1)
+{
+    ui.setupUi(this);
+
+    devices = TouchpadDevice::enumerate_from_udev();
+    for (const TouchpadDevice& device : devices)
+    {
+        ui.devicesComboBox->addItem(device.name());
+    }
+    if (devices.size())
+    {
+        curDevice = 0;
+    }
+
+    initControls();
+
+    connect(ui.tappingEnabledCheckBox, &QCheckBox::stateChanged,
+            this, &TouchpadConfig::setTappingEnabled);
+    connect(ui.naturalScrollingEnabledCheckBox, &QCheckBox::stateChanged,
+            this, &TouchpadConfig::setNaturalScrollingEnabled);
+    connect(ui.twoFingerScrollingRadioButton, &QRadioButton::toggled,
+            this, &TouchpadConfig::scrollingRadioButtonToggled);
+    connect(ui.edgeScrollingRadioButton, &QRadioButton::toggled,
+            this, &TouchpadConfig::scrollingRadioButtonToggled);
+    connect(ui.buttonScrollingRadioButton, &QRadioButton::toggled,
+            this, &TouchpadConfig::scrollingRadioButtonToggled);
+}
+
+TouchpadConfig::~TouchpadConfig()
+{
+}
+
+void TouchpadConfig::initFeatureControl(QCheckBox* control, int featureEnabled)
+{
+    if (featureEnabled >= 0)
+    {
+        control->setEnabled(true);
+        control->setCheckState(featureEnabled ? Qt::Checked : Qt::Unchecked);
+    }
+    else
+    {
+        control->setEnabled(false);
+    }
+}
+
+void TouchpadConfig::initControls()
+{
+    const TouchpadDevice& device = devices[curDevice];
+    initFeatureControl(ui.tappingEnabledCheckBox, device.tappingEnabled());
+    initFeatureControl(ui.naturalScrollingEnabledCheckBox, device.naturalScrollingEnabled());
+
+    int scrollMethodsAvailable = device.scrollMethodsAvailable();
+    ui.twoFingerScrollingRadioButton->setEnabled(scrollMethodsAvailable & TWO_FINGER);
+    ui.edgeScrollingRadioButton->setEnabled(scrollMethodsAvailable & EDGE);
+    ui.buttonScrollingRadioButton->setEnabled(scrollMethodsAvailable & BUTTON);
+
+    ScrollingMethod scrollingMethodEnabled = device.scrollingMethodEnabled();
+    if (scrollingMethodEnabled == TWO_FINGER)
+    {
+        ui.twoFingerScrollingRadioButton->setChecked(true);
+    }
+    else if (scrollingMethodEnabled == EDGE)
+    {
+        ui.edgeScrollingRadioButton->setChecked(true);
+    }
+    else if (scrollingMethodEnabled == BUTTON)
+    {
+        ui.buttonScrollingRadioButton->setChecked(true);
+    }
+    else
+    {
+        ui.noScrollingRadioButton->setChecked(true);
+    }
+}
+
+void TouchpadConfig::accept()
+{
+    settings->beginGroup("Touchpad");
+    for (const TouchpadDevice& device : devices)
+    {
+        // device names may contain '/' or '\\' so it should be escaped first
+        // XXX: special characters are double escaped (see writeIniFile in qsettings.cpp)
+        settings->beginGroup(QUrl::toPercentEncoding(device.name(), QByteArray(), QByteArray("/\\")));
+        settings->setValue("tappingEnabled", device.tappingEnabled());
+        settings->setValue("naturalScrollingEnabled", device.naturalScrollingEnabled());
+        settings->setValue("scrollingMethodEnabled", device.scrollingMethodEnabled());
+        settings->endGroup();
+    }
+    settings->endGroup();
+}
+
+void TouchpadConfig::reset()
+{
+    for (TouchpadDevice& device : devices)
+    {
+        device.setTappingEnabled(device.oldTappingEnabled());
+        device.setNaturalScrollingEnabled(device.oldNaturalScrollingEnabled());
+        device.setScrollingMethodEnabled(device.oldScrollingMethodEnabled());
+    }
+    initControls();
+    accept();
+}
+
+void TouchpadConfig::setTappingEnabled(int state)
+{
+    devices[curDevice].setTappingEnabled(state == Qt::Checked);
+    accept();
+}
+
+void TouchpadConfig::setNaturalScrollingEnabled(int state)
+{
+    devices[curDevice].setNaturalScrollingEnabled(state == Qt::Checked);
+    accept();
+}
+
+void TouchpadConfig::scrollingRadioButtonToggled()
+{
+    TouchpadDevice& device = devices[curDevice];
+    if (ui.noScrollingRadioButton->isChecked())
+    {
+        device.setScrollingMethodEnabled(NONE);
+    }
+    else if (ui.twoFingerScrollingRadioButton->isChecked())
+    {
+        device.setScrollingMethodEnabled(TWO_FINGER);
+    }
+    else if (ui.edgeScrollingRadioButton->isChecked())
+    {
+        device.setScrollingMethodEnabled(EDGE);
+    }
+    else if (ui.buttonScrollingRadioButton->isChecked())
+    {
+        device.setScrollingMethodEnabled(BUTTON);
+    }
+    accept();
+}

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -46,6 +46,8 @@ TouchpadConfig::TouchpadConfig(LXQt::Settings* _settings, QWidget* parent):
             this, &TouchpadConfig::setTappingEnabled);
     connect(ui.naturalScrollingEnabledCheckBox, &QCheckBox::stateChanged,
             this, &TouchpadConfig::setNaturalScrollingEnabled);
+    connect(ui.tapToDragEnabledCheckBox, &QCheckBox::stateChanged,
+            this, &TouchpadConfig::setTapToDragEnabled);
     connect(ui.twoFingerScrollingRadioButton, &QRadioButton::toggled,
             this, &TouchpadConfig::scrollingRadioButtonToggled);
     connect(ui.edgeScrollingRadioButton, &QRadioButton::toggled,
@@ -80,6 +82,7 @@ void TouchpadConfig::initControls()
     const TouchpadDevice& device = devices[curDevice];
     initFeatureControl(ui.tappingEnabledCheckBox, device.tappingEnabled());
     initFeatureControl(ui.naturalScrollingEnabledCheckBox, device.naturalScrollingEnabled());
+    initFeatureControl(ui.tapToDragEnabledCheckBox, device.tapToDragEnabled());
 
     int scrollMethodsAvailable = device.scrollMethodsAvailable();
     ui.twoFingerScrollingRadioButton->setEnabled(scrollMethodsAvailable & TWO_FINGER);
@@ -126,6 +129,7 @@ void TouchpadConfig::reset()
     {
         device.setTappingEnabled(device.oldTappingEnabled());
         device.setNaturalScrollingEnabled(device.oldNaturalScrollingEnabled());
+        device.setTapToDragEnabled(device.oldTapToDragEnabled());
         device.setScrollingMethodEnabled(device.oldScrollingMethodEnabled());
     }
     initControls();
@@ -141,6 +145,12 @@ void TouchpadConfig::setTappingEnabled(int state)
 void TouchpadConfig::setNaturalScrollingEnabled(int state)
 {
     devices[curDevice].setNaturalScrollingEnabled(state == Qt::Checked);
+    accept();
+}
+
+void TouchpadConfig::setTapToDragEnabled(int state)
+{
+    devices[curDevice].setTapToDragEnabled(state == Qt::Checked);
     accept();
 }
 

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -72,6 +72,10 @@ void TouchpadConfig::initFeatureControl(QCheckBox* control, int featureEnabled)
 
 void TouchpadConfig::initControls()
 {
+    if (curDevice < 0) {
+        return;
+    }
+
     const TouchpadDevice& device = devices[curDevice];
     initFeatureControl(ui.tappingEnabledCheckBox, device.tappingEnabled());
     initFeatureControl(ui.naturalScrollingEnabledCheckBox, device.naturalScrollingEnabled());

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -106,18 +106,10 @@ void TouchpadConfig::initControls()
 
 void TouchpadConfig::accept()
 {
-    settings->beginGroup("Touchpad");
     for (const TouchpadDevice& device : devices)
     {
-        // device names may contain '/' or '\\' so it should be escaped first
-        // XXX: special characters are double escaped (see writeIniFile in qsettings.cpp)
-        settings->beginGroup(QUrl::toPercentEncoding(device.name(), QByteArray(), QByteArray("/\\")));
-        settings->setValue("tappingEnabled", device.tappingEnabled());
-        settings->setValue("naturalScrollingEnabled", device.naturalScrollingEnabled());
-        settings->setValue("scrollingMethodEnabled", device.scrollingMethodEnabled());
-        settings->endGroup();
+        device.saveSettings(settings);
     }
-    settings->endGroup();
 }
 
 void TouchpadConfig::reset()

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+    Copyright (C) 2016-2018 Chih-Hsuan Yen <yan12125@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -20,6 +20,7 @@
 #include "touchpaddevice.h"
 
 #include <QUrl>
+#include <LXQt/AutostartEntry>
 #include <LXQt/Settings>
 
 TouchpadConfig::TouchpadConfig(LXQt::Settings* _settings, QWidget* parent):
@@ -110,6 +111,13 @@ void TouchpadConfig::accept()
     {
         device.saveSettings(settings);
     }
+
+    LXQt::AutostartEntry autoStart("lxqt-config-touchpad-autostart.desktop");
+    XdgDesktopFile desktopFile(XdgDesktopFile::ApplicationType, "lxqt-config-touchpad-autostart", "lxqt-config-input --load-touchpad");
+    desktopFile.setValue("OnlyShowIn", "LXQt");
+    desktopFile.setValue("Comment", "Autostart touchpad settings for lxqt-config-input");
+    autoStart.setFile(desktopFile);
+    autoStart.commit();
 }
 
 void TouchpadConfig::reset()

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -52,6 +52,7 @@ private:
     void initFeatureControl(QCheckBox* control, int featureEnabled);
     void setTappingEnabled(int state);
     void setNaturalScrollingEnabled(int state);
+    void setTapToDragEnabled(int state);
 };
 
 #endif

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -1,0 +1,57 @@
+/*
+    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef TOUCHPADCONFIG_H
+#define TOUCHPADCONFIG_H
+
+#include <QWidget>
+#include "ui_touchpadconfig.h"
+
+namespace LXQt
+{
+    class Settings;
+}
+
+class TouchpadDevice;
+
+class TouchpadConfig : public QWidget
+{
+    Q_OBJECT
+
+public:
+    TouchpadConfig(LXQt::Settings* _settings, QWidget* parent);
+    virtual ~TouchpadConfig();
+
+    void accept();
+public Q_SLOTS:
+    void reset();
+    void scrollingRadioButtonToggled();
+
+private:
+    LXQt::Settings* settings;
+    Ui::TouchpadConfig ui;
+    QList<TouchpadDevice> devices;
+    int curDevice;
+
+    void initControls();
+    void initFeatureControl(QCheckBox* control, int featureEnabled);
+    void setTappingEnabled(int state);
+    void setNaturalScrollingEnabled(int state);
+};
+
+#endif

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+    Copyright (C) 2016-2018 Chih-Hsuan Yen <yan12125@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -53,6 +53,7 @@ private:
     void setTappingEnabled(int state);
     void setNaturalScrollingEnabled(int state);
     void setTapToDragEnabled(int state);
+    void setAccelSpeed(float speed);
 };
 
 #endif

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -19,7 +19,7 @@
      <x>0</x>
      <y>10</y>
      <width>551</width>
-     <height>192</height>
+     <height>265</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -34,6 +34,33 @@
       </item>
       <item>
        <widget class="QComboBox" name="devicesComboBox"/>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Acceleration speed</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="accelSpeedDoubleSpinBox">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
       </item>
      </layout>
     </item>

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -40,7 +40,7 @@
     <item>
      <widget class="QCheckBox" name="tappingEnabledCheckBox">
       <property name="text">
-       <string>Tapping</string>
+       <string>Single click to activate items</string>
       </property>
      </widget>
     </item>

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TouchpadConfig</class>
+ <widget class="QWidget" name="TouchpadConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>559</width>
+    <height>298</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>TouchpadConfig </string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>10</y>
+     <width>551</width>
+     <height>171</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,2">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Device</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="devicesComboBox"/>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="tappingEnabledCheckBox">
+      <property name="text">
+       <string>Tapping</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="naturalScrollingEnabledCheckBox">
+      <property name="text">
+       <string>Natural Scrolling</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Scrolling</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="noScrollingRadioButton">
+        <property name="text">
+         <string>Disabled</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="twoFingerScrollingRadioButton">
+        <property name="text">
+         <string>Two-Finger</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="edgeScrollingRadioButton">
+        <property name="text">
+         <string>Edge</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="buttonScrollingRadioButton">
+        <property name="text">
+         <string>Button</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <zorder>verticalLayoutWidget</zorder>
+  <zorder>naturalScrollingEnabledCheckBox</zorder>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -19,7 +19,7 @@
      <x>0</x>
      <y>10</y>
      <width>551</width>
-     <height>171</height>
+     <height>192</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -48,6 +48,13 @@
      <widget class="QCheckBox" name="naturalScrollingEnabledCheckBox">
       <property name="text">
        <string>Natural Scrolling</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="tapToDragEnabledCheckBox">
+      <property name="text">
+       <string>Tap to drag</string>
       </property>
      </widget>
     </item>
@@ -92,8 +99,6 @@
     </item>
    </layout>
   </widget>
-  <zorder>verticalLayoutWidget</zorder>
-  <zorder>naturalScrollingEnabledCheckBox</zorder>
  </widget>
  <resources/>
  <connections/>

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -24,7 +24,7 @@
 #include <LXQt/Settings>
 #include <X11/Xatom.h>
 #include <X11/extensions/XInput2.h>
-#include <xorg/libinput-properties.h>
+#include <libinput-properties.h>
 
 static QList<QVariant> xi2_get_device_property(int deviceid, const char* prop)
 {

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -162,6 +162,7 @@ QList<TouchpadDevice> TouchpadDevice::enumerate_from_udev()
     
     udev_enumerate *enumerate = udev_enumerate_new(ud);
     udev_enumerate_add_match_property(enumerate, "ID_INPUT_TOUCHPAD", "1");
+    udev_enumerate_add_match_property(enumerate, "ID_INPUT_MOUSE", "1");
     udev_enumerate_scan_devices(enumerate);
     udev_list_entry *devices = udev_enumerate_get_list_entry(enumerate);
     for (udev_list_entry *entry = devices; entry; entry = udev_list_entry_get_next(entry)) {
@@ -254,6 +255,10 @@ int TouchpadDevice::scrollMethodsAvailable() const
 {
     QList<QVariant> values = get_xi2_property(LIBINPUT_PROP_SCROLL_METHODS_AVAILABLE);
 
+    if (!values.size()) {
+        return 0;
+    }
+
     Q_ASSERT(values.size() == 3);
 
     return (values[0].toInt() ? TWO_FINGER : 0) |
@@ -264,6 +269,10 @@ int TouchpadDevice::scrollMethodsAvailable() const
 ScrollingMethod TouchpadDevice::scrollingMethodEnabled() const
 {
     QList<QVariant> values = get_xi2_property(LIBINPUT_PROP_SCROLL_METHOD_ENABLED);
+
+    if (!values.size()) {
+        return NONE;
+    }
 
     Q_ASSERT(values.size() == 3);
     

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -180,6 +180,7 @@ QList<TouchpadDevice> TouchpadDevice::enumerate_from_udev()
                 qDebug() << "Detected" << dev.m_name << "on" << dev.devnode;
                 dev.m_oldTappingEnabled = dev.tappingEnabled();
                 dev.m_oldNaturalScrollingEnabled = dev.naturalScrollingEnabled();
+                dev.m_oldTapToDragEnabled = dev.tapToDragEnabled();
                 dev.m_oldScrollingMethodEnabled = dev.scrollingMethodEnabled();
                 ret << dev;
             }
@@ -240,6 +241,9 @@ void TouchpadDevice::loadSettings(LXQt::Settings* settings)
         if (settings->contains(NATURAL_SCROLLING_ENABLED)) {
             device.setNaturalScrollingEnabled(settings->value(NATURAL_SCROLLING_ENABLED).toBool());
         }
+        if (settings->contains(TAP_TO_DRAG_ENABLED)) {
+            device.setTapToDragEnabled(settings->value(TAP_TO_DRAG_ENABLED).toBool());
+        }
         if (settings->contains(SCROLLING_METHOD_ENABLED)) {
             device.setScrollingMethodEnabled(
                 static_cast<ScrollingMethod>(settings->value(SCROLLING_METHOD_ENABLED).toInt()));
@@ -256,6 +260,7 @@ void TouchpadDevice::saveSettings(LXQt::Settings* settings) const
     settings->beginGroup(escapedName());
     settings->setValue(TAPPING_ENABLED, tappingEnabled());
     settings->setValue(NATURAL_SCROLLING_ENABLED, naturalScrollingEnabled());
+    settings->setValue(TAP_TO_DRAG_ENABLED, tapToDragEnabled());
     settings->setValue(SCROLLING_METHOD_ENABLED, scrollingMethodEnabled());
     settings->endGroup(); // device name
 
@@ -285,6 +290,11 @@ int TouchpadDevice::naturalScrollingEnabled() const
     return featureEnabled(LIBINPUT_PROP_NATURAL_SCROLL);
 }
 
+int TouchpadDevice::tapToDragEnabled() const
+{
+    return featureEnabled(LIBINPUT_PROP_TAP_DRAG);
+}
+
 bool TouchpadDevice::setTappingEnabled(bool enabled) const
 {
     return set_xi2_property(LIBINPUT_PROP_TAP, QList<QVariant>({enabled ? 1 : 0}));
@@ -293,6 +303,11 @@ bool TouchpadDevice::setTappingEnabled(bool enabled) const
 bool TouchpadDevice::setNaturalScrollingEnabled(bool enabled) const
 {
     return set_xi2_property(LIBINPUT_PROP_NATURAL_SCROLL, QList<QVariant>({enabled ? 1 : 0}));
+}
+
+bool TouchpadDevice::setTapToDragEnabled(bool enabled) const
+{
+    return set_xi2_property(LIBINPUT_PROP_TAP_DRAG, QList<QVariant>({enabled ? 1 : 0}));
 }
 
 int TouchpadDevice::scrollMethodsAvailable() const

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -1,0 +1,290 @@
+/*
+    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "touchpaddevice.h"
+
+#include <QDebug>
+#include <QX11Info>
+#include <libudev.h>
+#include <X11/Xatom.h>
+#include <X11/extensions/XInput2.h>
+#include <xorg/libinput-properties.h>
+
+static QList<QVariant> xi2_get_device_property(int deviceid, const char* prop)
+{
+    QList<QVariant> ret;
+
+    Display* dpy = QX11Info::display();
+
+    Atom act_type;
+    int act_format;
+    unsigned long nitems, bytes_after;
+    unsigned char *data, *ptr;
+    Atom prop_atom = XInternAtom(dpy, prop, False);
+    XIGetProperty(dpy, deviceid, prop_atom, 0, 1000, False, AnyPropertyType,
+                  &act_type, &act_format, &nitems, &bytes_after, &data);
+    ptr = data;
+    for (unsigned long i = 0; i < nitems; i++)
+    {
+        switch (act_type)
+        {
+        case XA_INTEGER:
+            switch (act_format)
+            {
+            case 8:
+                ret << *reinterpret_cast<quint8*>(ptr);
+                break;
+            case 16:
+                ret << *reinterpret_cast<quint16*>(ptr);
+                break;
+            case 32:
+                ret << *reinterpret_cast<quint32*>(ptr);
+                break;
+            default:
+                Q_ASSERT(0);
+            }
+            ptr += act_format / 8;
+            break;
+        case XA_STRING:
+        {
+            Q_ASSERT(act_format == 8);
+            QString s(reinterpret_cast<char*>(ptr));
+            ptr += s.size() + 1; // including '\0'
+            ret << s;
+            break;
+        }
+        default:
+            qWarning() << "Unrecognized type " << act_type << " for property " << prop;
+        }
+    }
+
+    XFree(data);
+
+    return ret;
+}
+
+static bool xi2_set_device_property(int deviceid, const char* prop, QList<QVariant> values)
+{
+    Display* dpy = QX11Info::display();
+
+    Atom prop_atom = XInternAtom(dpy, prop, False);
+
+    Atom act_type;
+    int act_format;
+    unsigned long nitems, bytes_after;
+    unsigned char *data;
+    // get the property first to determine its type and format
+    XIGetProperty(dpy, deviceid, prop_atom, 0, 1000, False, AnyPropertyType,
+                  &act_type, &act_format, &nitems, &bytes_after, &data);
+    if (!nitems)
+    {
+        return false;
+    }
+
+    XFree(data);
+
+    switch (values[0].type())
+    {
+    case QVariant::Int:
+        Q_ASSERT(act_type == XA_INTEGER);
+
+        data = new unsigned char[values.size() * act_format / 8];
+        for (int i = 0; i < values.size(); i++)
+        {
+            switch (act_format)
+            {
+            case 8:
+                *reinterpret_cast<int8_t*>(data + i) = values[i].toInt();
+                break;
+            case 16:
+                *reinterpret_cast<int16_t*>(data + i) = values[i].toInt();
+                break;
+            case 32:
+                *reinterpret_cast<int32_t*>(data + i) = values[i].toInt();
+                break;
+            default:
+                Q_ASSERT(0);
+            }
+        }
+        break;
+    default:
+        qWarning("Unsupported data type");
+    }
+    if (!data)
+    {
+        return false;
+    }
+    XIChangeProperty(dpy, deviceid, prop_atom, act_type, act_format,
+                     XIPropModeReplace, data, values.size());
+    // XXX How to catch errors?
+    return true;
+}
+
+QList<QVariant> TouchpadDevice::get_xi2_property(const char* prop) const
+{
+    Q_ASSERT(deviceid);
+
+    return xi2_get_device_property(deviceid, prop);
+}
+
+bool TouchpadDevice::set_xi2_property(const char* prop, QList<QVariant> values)
+{
+    Q_ASSERT(deviceid);
+
+    return xi2_set_device_property(deviceid, prop, values);
+}
+
+QList<TouchpadDevice> TouchpadDevice::enumerate_from_udev()
+{
+    QList<TouchpadDevice> ret;
+    udev *ud = udev_new();
+
+    if (!ud)
+    {
+        qWarning() << "Fails to initialize udev";
+        return ret;
+    }
+    
+    udev_enumerate *enumerate = udev_enumerate_new(ud);
+    udev_enumerate_add_match_property(enumerate, "ID_INPUT_TOUCHPAD", "1");
+    udev_enumerate_scan_devices(enumerate);
+    udev_list_entry *devices = udev_enumerate_get_list_entry(enumerate);
+    for (udev_list_entry *entry = devices; entry; entry = udev_list_entry_get_next(entry)) {
+        const char *path = udev_list_entry_get_name(entry);
+        udev_device *dev = udev_device_new_from_syspath(ud, path);
+
+        const char* devnode = udev_device_get_devnode(dev);
+        if (devnode)
+        {
+            TouchpadDevice dev;
+            dev.devnode = devnode;
+            if(dev.find_xi2_device())
+            {
+                qDebug() << "Detected" << dev.m_name << "on" << dev.devnode;
+                dev.m_oldTappingEnabled = dev.tappingEnabled();
+                dev.m_oldNaturalScrollingEnabled = dev.naturalScrollingEnabled();
+                dev.m_oldScrollingMethodEnabled = dev.scrollingMethodEnabled();
+                ret << dev;
+            }
+        }
+
+        udev_device_unref(dev);
+    }
+    udev_enumerate_unref(enumerate);
+    udev_unref(ud);
+
+    return ret;
+}
+
+
+bool TouchpadDevice::find_xi2_device()
+{
+    Display* dpy = QX11Info::display();
+
+    int ndevices;
+    bool found = false;
+    XIDeviceInfo *info = XIQueryDevice(dpy, XIAllDevices, &ndevices);
+
+    for(int i = 0; i < ndevices ; i++)
+    {
+        QList<QVariant> devnode_prop = xi2_get_device_property(info[i].deviceid, "Device Node");
+        if (devnode_prop.size() && devnode_prop[0].toString() == devnode)
+        {
+            m_name = info[i].name;
+            deviceid = info[i].deviceid;
+            found = true;
+            break;
+        }
+    }
+
+    XIFreeDeviceInfo(info);
+
+    return found;
+}
+
+int TouchpadDevice::featureEnabled(const char* prop) const
+{
+    QList<QVariant> propVal = get_xi2_property(prop);
+    if (propVal.size())
+    {
+        return propVal[0].toInt();
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+int TouchpadDevice::tappingEnabled() const
+{
+    return featureEnabled(LIBINPUT_PROP_TAP);
+}
+
+int TouchpadDevice::naturalScrollingEnabled() const
+{
+    return featureEnabled(LIBINPUT_PROP_NATURAL_SCROLL);
+}
+
+bool TouchpadDevice::setTappingEnabled(bool enabled)
+{
+    return set_xi2_property(LIBINPUT_PROP_TAP, QList<QVariant>({enabled ? 1 : 0}));
+}
+
+bool TouchpadDevice::setNaturalScrollingEnabled(bool enabled)
+{
+    return set_xi2_property(LIBINPUT_PROP_NATURAL_SCROLL, QList<QVariant>({enabled ? 1 : 0}));
+}
+
+int TouchpadDevice::scrollMethodsAvailable() const
+{
+    QList<QVariant> values = get_xi2_property(LIBINPUT_PROP_SCROLL_METHODS_AVAILABLE);
+
+    Q_ASSERT(values.size() == 3);
+
+    return (values[0].toInt() ? TWO_FINGER : 0) |
+           (values[1].toInt() ? EDGE : 0) |
+           (values[2].toInt() ? BUTTON : 0);
+}
+
+ScrollingMethod TouchpadDevice::scrollingMethodEnabled() const
+{
+    QList<QVariant> values = get_xi2_property(LIBINPUT_PROP_SCROLL_METHOD_ENABLED);
+
+    Q_ASSERT(values.size() == 3);
+    
+    // those methods are mutually exclusive
+    if (values[0].toInt())
+        return TWO_FINGER;
+    else if (values[1].toInt())
+        return EDGE;
+    else if (values[2].toInt())
+        return BUTTON;
+    else
+        return NONE;
+}
+
+bool TouchpadDevice::setScrollingMethodEnabled(ScrollingMethod method)
+{
+    QList<QVariant> values;
+
+    values << ((method == TWO_FINGER) ? 1 : 0);
+    values << ((method == EDGE) ? 1 : 0);
+    values << ((method == BUTTON) ? 1 : 0);
+
+    return set_xi2_property(LIBINPUT_PROP_SCROLL_METHOD_ENABLED, values);
+}

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+    Copyright (C) 2016-2018 Chih-Hsuan Yen <yan12125@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -38,6 +38,7 @@ const char TAPPING_ENABLED[] = "tappingEnabled";
 const char NATURAL_SCROLLING_ENABLED[] = "naturalScrollingEnabled";
 const char TAP_TO_DRAG_ENABLED[] = "tapToDragEnabled";
 const char SCROLLING_METHOD_ENABLED[] = "scrollingMethodEnabled";
+const char ACCELERATION_SPEED[] = "accelSpeed";
 
 class TouchpadDevice
 {
@@ -52,13 +53,16 @@ public:
     int tappingEnabled() const;
     int naturalScrollingEnabled() const;
     int tapToDragEnabled() const;
+    float accelSpeed() const;
     bool setTappingEnabled(bool enabled) const;
     bool setNaturalScrollingEnabled(bool enabled) const;
     bool setTapToDragEnabled(bool enabled) const;
+    bool setAccelSpeed(float speed) const;
     bool oldTappingEnabled() const { return m_oldTappingEnabled; }
     bool oldNaturalScrollingEnabled() const { return m_oldNaturalScrollingEnabled; }
     bool oldTapToDragEnabled() const { return m_oldTapToDragEnabled; }
     ScrollingMethod oldScrollingMethodEnabled() const { return m_oldScrollingMethodEnabled; }
+    float oldAccelSpeed() const { return m_oldAccelSpeed; }
 
     int scrollMethodsAvailable() const;
     ScrollingMethod scrollingMethodEnabled() const;
@@ -74,6 +78,7 @@ private:
     bool m_oldTappingEnabled;
     bool m_oldNaturalScrollingEnabled;
     bool m_oldTapToDragEnabled;
+    float m_oldAccelSpeed;
     ScrollingMethod m_oldScrollingMethodEnabled;
 
     QList<QVariant> get_xi2_property(const char* prop) const;

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -36,6 +36,7 @@ enum ScrollingMethod
 
 const char TAPPING_ENABLED[] = "tappingEnabled";
 const char NATURAL_SCROLLING_ENABLED[] = "naturalScrollingEnabled";
+const char TAP_TO_DRAG_ENABLED[] = "tapToDragEnabled";
 const char SCROLLING_METHOD_ENABLED[] = "scrollingMethodEnabled";
 
 class TouchpadDevice
@@ -50,10 +51,13 @@ public:
 
     int tappingEnabled() const;
     int naturalScrollingEnabled() const;
+    int tapToDragEnabled() const;
     bool setTappingEnabled(bool enabled) const;
     bool setNaturalScrollingEnabled(bool enabled) const;
+    bool setTapToDragEnabled(bool enabled) const;
     bool oldTappingEnabled() const { return m_oldTappingEnabled; }
     bool oldNaturalScrollingEnabled() const { return m_oldNaturalScrollingEnabled; }
+    bool oldTapToDragEnabled() const { return m_oldTapToDragEnabled; }
     ScrollingMethod oldScrollingMethodEnabled() const { return m_oldScrollingMethodEnabled; }
 
     int scrollMethodsAvailable() const;
@@ -69,6 +73,7 @@ private:
 
     bool m_oldTappingEnabled;
     bool m_oldNaturalScrollingEnabled;
+    bool m_oldTapToDragEnabled;
     ScrollingMethod m_oldScrollingMethodEnabled;
 
     QList<QVariant> get_xi2_property(const char* prop) const;

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -22,6 +22,10 @@
 #include <QList>
 #include <QVariant>
 
+namespace LXQt {
+    class Settings;
+}
+
 enum ScrollingMethod
 {
     NONE = 0,
@@ -29,6 +33,10 @@ enum ScrollingMethod
     EDGE = 2,
     BUTTON = 4
 };
+
+const char TAPPING_ENABLED[] = "tappingEnabled";
+const char NATURAL_SCROLLING_ENABLED[] = "naturalScrollingEnabled";
+const char SCROLLING_METHOD_ENABLED[] = "scrollingMethodEnabled";
 
 class TouchpadDevice
 {
@@ -38,18 +46,22 @@ public:
     static QList<TouchpadDevice> enumerate_from_udev();
 
     const QString& name() const { return m_name; }
+    QString escapedName() const;
 
     int tappingEnabled() const;
     int naturalScrollingEnabled() const;
-    bool setTappingEnabled(bool enabled);
-    bool setNaturalScrollingEnabled(bool enabled);
+    bool setTappingEnabled(bool enabled) const;
+    bool setNaturalScrollingEnabled(bool enabled) const;
     bool oldTappingEnabled() const { return m_oldTappingEnabled; }
     bool oldNaturalScrollingEnabled() const { return m_oldNaturalScrollingEnabled; }
     ScrollingMethod oldScrollingMethodEnabled() const { return m_oldScrollingMethodEnabled; }
 
     int scrollMethodsAvailable() const;
     ScrollingMethod scrollingMethodEnabled() const;
-    bool setScrollingMethodEnabled(ScrollingMethod method);
+    bool setScrollingMethodEnabled(ScrollingMethod method) const;
+
+    static void loadSettings(LXQt::Settings* settings);
+    void saveSettings(LXQt::Settings* settings) const;
 private:
     QString m_name;
     QString devnode;
@@ -60,7 +72,7 @@ private:
     ScrollingMethod m_oldScrollingMethodEnabled;
 
     QList<QVariant> get_xi2_property(const char* prop) const;
-    bool set_xi2_property(const char* prop, QList<QVariant> values);
+    bool set_xi2_property(const char* prop, QList<QVariant> values) const;
     bool find_xi2_device();
     int featureEnabled(const char* prop) const;
 };

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -1,0 +1,68 @@
+/*
+    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef TOUCHPADDEVICE_H
+#define TOUCHPADDEVICE_H
+
+#include <QList>
+#include <QVariant>
+
+enum ScrollingMethod
+{
+    NONE = 0,
+    TWO_FINGER = 1,
+    EDGE = 2,
+    BUTTON = 4
+};
+
+class TouchpadDevice
+{
+public:
+    TouchpadDevice(): deviceid(0) {}
+
+    static QList<TouchpadDevice> enumerate_from_udev();
+
+    const QString& name() const { return m_name; }
+
+    int tappingEnabled() const;
+    int naturalScrollingEnabled() const;
+    bool setTappingEnabled(bool enabled);
+    bool setNaturalScrollingEnabled(bool enabled);
+    bool oldTappingEnabled() const { return m_oldTappingEnabled; }
+    bool oldNaturalScrollingEnabled() const { return m_oldNaturalScrollingEnabled; }
+    ScrollingMethod oldScrollingMethodEnabled() const { return m_oldScrollingMethodEnabled; }
+
+    int scrollMethodsAvailable() const;
+    ScrollingMethod scrollingMethodEnabled() const;
+    bool setScrollingMethodEnabled(ScrollingMethod method);
+private:
+    QString m_name;
+    QString devnode;
+    int deviceid;
+
+    bool m_oldTappingEnabled;
+    bool m_oldNaturalScrollingEnabled;
+    ScrollingMethod m_oldScrollingMethodEnabled;
+
+    QList<QVariant> get_xi2_property(const char* prop) const;
+    bool set_xi2_property(const char* prop, QList<QVariant> values);
+    bool find_xi2_device();
+    int featureEnabled(const char* prop) const;
+};
+
+#endif

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016 Yen Chi Hsuan <yan12125@gmail.com>
+    Copyright (C) 2016-2018 Chih-Hsuan Yen <yan12125@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
WARNING: incomplete implementation

This is the first step to https://github.com/lxde/lxqt/issues/92.

Notes:

1. Depends on X11, udev and libinput. Only xf86-input-libinput driver is supported. Other vendor specific drivers are not supported. I don't plan to implement drivers other than libinput as the latter is preferred now. For example, [Arch Linux](https://git.archlinux.org/svntogit/packages.git/tree/trunk/xf86-input-synaptics.install?h=packages/xf86-input-synaptics), [Fedora](https://www.phoronix.com/scan.php?page=news_item&px=Switching-To-Libinput-Xorg) and [Gnome](https://lists.debian.org/debian-devel/2016/07/msg00266.html) suggests moving to libinput
2. Tested only on Arch Linux with systemd's udev. On systems other than Linux, I guess things won't compile at all
3. Unlike other configuration tools, the default values are loaded from X.org
4. You need to run this tool every time after starting up LXQt. I haven't added codes that load touchpad settings to lxqt-session yet
5. New to UI/UX. Hope to hear opinions on the UI design

TODO:

1. Check udev and libinput in CMakeLists.txt
2. Handle non-libinput drivers properly
3. Add "Device Enabled"