### PR TITLE
lxqt-config-brightness: Sets minimum backlight value to 0

### DIFF
--- a/lxqt-config-brightness/brightnesssettings.cpp
+++ b/lxqt-config-brightness/brightnesssettings.cpp
@@ -33,7 +33,7 @@ BrightnessSettings::BrightnessSettings(QWidget *parent):QDialog(parent)
     ui->backlightSlider->setEnabled(mBacklight->isBacklightAvailable() || mBacklight->isBacklightOff());
     if(mBacklight->isBacklightAvailable()) {
         ui->backlightSlider->setMaximum(mBacklight->getMaxBacklight());
-        ui->backlightSlider->setMinimum((float)(mBacklight->getMaxBacklight())*0.02);
+        ui->backlightSlider->setMinimum(0);
         ui->backlightSlider->setValue(mLastBacklightValue = mBacklight->getBacklight());
         connect(ui->backlightSlider, &QSlider::valueChanged, this, &BrightnessSettings::setBacklight);
     }


### PR DESCRIPTION
According to the kernel documentation, backlight vValues are between 0 and
max_brightness.

Reference:
https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-backlight