### PR TITLE
Remove time-out from backlight slider

### DIFF
--- a/lxqt-config-brightness/brightnesssettings.h
+++ b/lxqt-config-brightness/brightnesssettings.h
@@ -39,12 +39,13 @@ signals:
 public slots:
     void monitorSettingsChanged(MonitorInfo monitor);
     void requestConfirmation();
-    void setBacklight(int value);
+    void setBacklight();
 
 private:
     XRandrBrightness *mBrightness;
     QList<MonitorInfo> mMonitors;
     QTimer mConfirmRequestTimer;
+    QTimer mBacklightTimer;
     Ui::BrightnessSettings *ui;
     LXQt::Backlight *mBacklight;
     int mLastBacklightValue;


### PR DESCRIPTION
Instead, prevent too fast changes to the backlight value by using a `QTimer`.

Also, set the minimum backlight value to 5% of its maximum because 2% is too dark.