### PR TITLE
Qt 5.11 beta: timeoutdialog.cpp: include QIcon, QStyle explicitely

### DIFF
--- a/lxqt-config-monitor/timeoutdialog.cpp
+++ b/lxqt-config-monitor/timeoutdialog.cpp
@@ -20,6 +20,9 @@
 
 #define TIMER_DURATION 10
 
+#include <QIcon>
+#include <QStyle>
+
 #include "timeoutdialog.h"
 
 TimeoutDialog::TimeoutDialog(QWidget* parent, Qt::WindowFlags f) :


### PR DESCRIPTION
5.11 Qt headers do not indirectly include QIcon, QStyle resulting in compile
time errors like:

| timeoutdialog.cpp:32:25: error: invalid use of incomplete type 'class QStyle'

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>