### PR TITLE
Remove unnecessary semicolon

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -68,7 +68,7 @@ private slots:
     void load();
 };
 
-}; // namespace
+} // namespace
 
 
 #endif


### PR DESCRIPTION
Fixes a compiler warning with Gcc:

    In file included from lxqt-config/src/main.cpp:30:
        lxqt-config/src/mainwindow.h:71:2: warning: extra ‘;’ [-Wpedantic]