### PR TITLE
Bugfix XRandrBrightness::backlight_get_with_range return value

### DIFF
--- a/lxqt-config-brightness/xrandrbrightness.cpp
+++ b/lxqt-config-brightness/xrandrbrightness.cpp
@@ -89,7 +89,7 @@ bool XRandrBrightness::backlight_get_with_range(xcb_randr_output_t output, long 
     , nullptr));
 
     if (!propertyReply) {
-        return -1;
+        return false;
     }
 
     if (propertyReply->range && xcb_randr_query_output_property_valid_values_length(propertyReply.data()) == 2) {


### PR DESCRIPTION
If propertyReply is false, we want to return false to indicate that
backlight_get_with_range failed. -1 is implicitly cast to true, so
change the return to return false.