### PR TITLE
Small GUI fixes

### DIFF
--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -79,12 +79,12 @@
         <item row="3" column="1">
          <widget class="QLabel" name="uniformThemeLabel">
           <property name="text">
-           <string>To attempt uniform theming, either select similar style/theme
-(if available) across all lists, or select 'gtk2' Qt style (if available)
- to mimic GTK themes.
+           <string>To attempt uniform theming, either select similar style/theme (if available) across all lists, or select 'gtk2' Qt style (if available) to mimic GTK themes.
 
-Make sure 'xsettingsd' is installed to help GTK applications apply
-themes on the fly.</string>
+Make sure 'xsettingsd' is installed to help GTK applications apply themes on the fly.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -187,6 +187,9 @@ public:
 protected:
     void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
     {
+        if(!index.isValid())
+            return;
+
         QStyleOptionViewItem opt = option;
         initStyleOption(&opt, index);
 
@@ -202,7 +205,9 @@ protected:
         opt.icon = QIcon(pixmap.copy(QRect(QPoint(0, 0), size * dpr)));
         opt.decorationSize = size;
 
-        QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &opt, painter);
+        const QWidget* widget = opt.widget;
+        QStyle* style = widget ? widget->style() : QApplication::style();
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
     }
 
 private:

--- a/src/qcategorizedview/qcategorizedview.cpp
+++ b/src/qcategorizedview/qcategorizedview.cpp
@@ -868,8 +868,8 @@ void QCategorizedView::paintEvent(QPaintEvent *event)
             } else {
                 option.state &= ~QStyle::State_Selected;
             }
-            option.state |= (index == currentIndex()) ? QStyle::State_HasFocus
-                                                      : QStyle::State_None;
+            option.state |= (index == currentIndex() && viewport()->hasFocus()) ? QStyle::State_HasFocus
+                                                                                : QStyle::State_None;
             if (!(flags & Qt::ItemIsEnabled)) {
                 option.state &= ~QStyle::State_Enabled;
             } else {


### PR DESCRIPTION
Among other things:

 * `QStyle::State_HasFocus` is only for focused viewports.
 * A single label line should be wrapped without internal line-ends.