### PR TITLE
Removed an old workaround that creates problems now

### DIFF
--- a/src/qcategorizedview/qcategorizedview.cpp
+++ b/src/qcategorizedview/qcategorizedview.cpp
@@ -516,7 +516,6 @@ void QCategorizedView::Private::_k_slotCollapseOrExpandClicked(QModelIndex)
 QCategorizedView::QCategorizedView(QWidget *parent)
     : QListView(parent)
     , d(new Private(this))
-    , enterPressed(false)
 {
 }
 
@@ -1535,45 +1534,6 @@ void QCategorizedView::slotLayoutChanged()
     if (d->proxyModel->rowCount()) {
         d->rowsInserted(rootIndex(), 0, d->proxyModel->rowCount() - 1);
     }
-}
-
-void QCategorizedView::keyPressEvent(QKeyEvent *event)
-{
-    // Don't emit activated() by pressing Enter! ...
-    switch (event->key()) {
-        case Qt::Key_Enter:
-        case Qt::Key_Return:
-            if (state() != EditingState) {
-              event->ignore();
-              if (hasFocus() && !event->isAutoRepeat())
-                  enterPressed = true; // Pressed after getting focus.
-              return;
-            }
-            break;
-        default: break;
-    }
-    QAbstractItemView::keyPressEvent(event);
-}
-
-void QCategorizedView::keyReleaseEvent(QKeyEvent *event)
-{
-    // ... Emit activated() by releasing Enter instead!
-    switch (event->key()) {
-        case Qt::Key_Enter:
-        case Qt::Key_Return:
-            if (hasFocus() && state() != EditingState
-                && !event->isAutoRepeat() // No multiple signals.
-                && enterPressed // No signal if Enter is pressed before getting focus.
-                && currentIndex().isValid()) {
-                emit activated(currentIndex());
-                event->accept();
-                enterPressed = false;
-                return;
-            }
-            break;
-        default: break;
-    }
-    QAbstractItemView::keyReleaseEvent(event);
 }
 
 //END: Public part

--- a/src/qcategorizedview/qcategorizedview.h
+++ b/src/qcategorizedview/qcategorizedview.h
@@ -318,9 +318,6 @@ protected:
                               int start,
                               int end);
 
-    void keyPressEvent(QKeyEvent *event);
-    void keyReleaseEvent(QKeyEvent *event);
-
 protected Q_SLOTS:
     /**
       * @internal
@@ -351,11 +348,6 @@ protected Q_SLOTS:
 private:
     class Private;
     Private *const d;
-    /**
-      * For knowing that Enter is pressed after
-      * the widget gets focus and not before that.
-      */
-    bool enterPressed;
 
     Q_PRIVATE_SLOT(d, void _k_slotCollapseOrExpandClicked(QModelIndex))
 };


### PR DESCRIPTION
Years ago, a workaround had been added for old versions of Qt5. However, not only it is not needed anymore but also it interferes with pressing `Enter` (messes with `Enter` after `Arrow`). So, it is reversed by this patch.

If someone can compile lxqt-config with an old version of Qt, they will see nothing special because the workaround didn't work well in old times.