### PR TITLE
Monitor name is added to output.

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -125,7 +125,10 @@ void MonitorSettingsDialog::loadConfiguration(KScreen::ConfigPtr config)
         if (output->isConnected())
         {
             MonitorWidget *monitor = new MonitorWidget(output, mConfig, this);
-            ui.monitorList->addItem(output->name() + " " + output->edid()->name() + " " + output->edid()->vendor());
+            QString monitorName = output->edid()->name() + " " + output->edid()->vendor();
+            if(monitorName.trimmed().size() > 0)
+                monitorName = "(" + monitorName + ")";
+            ui.monitorList->addItem(output->name() + " " + monitorName);
             ui.stackedWidget->addWidget(monitor);
             monitors.append(monitor);
         }

--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -125,7 +125,7 @@ void MonitorSettingsDialog::loadConfiguration(KScreen::ConfigPtr config)
         if (output->isConnected())
         {
             MonitorWidget *monitor = new MonitorWidget(output, mConfig, this);
-            ui.monitorList->addItem(output->name());
+            ui.monitorList->addItem(output->name() + " " + output->edid()->name() + " " + output->edid()->vendor());
             ui.stackedWidget->addWidget(monitor);
             monitors.append(monitor);
         }

--- a/lxqt-config-monitor/monitorsettingsdialog.ui
+++ b/lxqt-config-monitor/monitorsettingsdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>510</width>
+    <width>522</width>
     <height>131</height>
    </rect>
   </property>
@@ -15,8 +15,7 @@
   </property>
   <property name="windowIcon">
    <iconset theme="preferences-desktop-display">
-    <normaloff/>
-   </iconset>
+    <normaloff>.</normaloff>.</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -41,7 +40,7 @@
        </size>
       </property>
       <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
+       <enum>Qt::ScrollBarAsNeeded</enum>
       </property>
       <property name="resizeMode">
        <enum>QListView::Adjust</enum>
@@ -71,7 +70,8 @@
         <string>Settings</string>
        </property>
        <property name="icon">
-        <iconset theme="preferences-system"/>
+        <iconset theme="preferences-system">
+         <normaloff>.</normaloff>.</iconset>
        </property>
        <property name="toolButtonStyle">
         <enum>Qt::ToolButtonTextBesideIcon</enum>


### PR DESCRIPTION
The name of the screen is added to output name. In this picture the HDMI output shows the name of screen:
![monitor-name](https://user-images.githubusercontent.com/1163139/48234647-a9faac80-e3ba-11e8-9e09-edbd73663ac6.png)
Users can identify their screens easier.