### PR TITLE
Fixed touchpad settings

### DIFF
--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
     QObject::connect(&dlg, SIGNAL(reset()), keyboardLayoutConfig, SLOT(reset()));
 
     TouchpadConfig* touchpadConfig = new TouchpadConfig(&settings, &dlg);
-    dlg.addPage(touchpadConfig, QObject::tr("Touchpad"), "input-tablet");
+    dlg.addPage(touchpadConfig, QObject::tr("Mouse and Touchpad"), "input-tablet");
     QObject::connect(&dlg, &LXQt::ConfigDialog::reset,
                      touchpadConfig, &TouchpadConfig::reset);
 

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -46,13 +46,12 @@ private:
     LXQt::Settings* settings;
     Ui::TouchpadConfig ui;
     QList<TouchpadDevice> devices;
-    int curDevice;
 
     void initControls();
     void initFeatureControl(QCheckBox* control, int featureEnabled);
-    void setTappingEnabled(int state);
-    void setNaturalScrollingEnabled(int state);
-    void setTapToDragEnabled(int state);
+    void setTappingEnabled();
+    void setNaturalScrollingEnabled();
+    void setTapToDragEnabled();
     void setAccelSpeed(float speed);
 };
 

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -6,126 +6,140 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>559</width>
-    <height>298</height>
+    <width>450</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>TouchpadConfig </string>
   </property>
-  <widget class="QWidget" name="verticalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>10</y>
-     <width>551</width>
-     <height>265</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,2">
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Device</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="devicesComboBox"/>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Acceleration speed</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QDoubleSpinBox" name="accelSpeedDoubleSpinBox">
-        <property name="decimals">
-         <number>2</number>
-        </property>
-        <property name="minimum">
-         <double>-1.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="QCheckBox" name="tappingEnabledCheckBox">
-      <property name="text">
-       <string>Single click to activate items</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QCheckBox" name="naturalScrollingEnabledCheckBox">
-      <property name="text">
-       <string>Natural Scrolling</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QCheckBox" name="tapToDragEnabledCheckBox">
-      <property name="text">
-       <string>Tap to drag</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_6">
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Scrolling</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="noScrollingRadioButton">
-        <property name="text">
-         <string>Disabled</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="twoFingerScrollingRadioButton">
-        <property name="text">
-         <string>Two-Finger</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="edgeScrollingRadioButton">
-        <property name="text">
-         <string>Edge</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="buttonScrollingRadioButton">
-        <property name="text">
-         <string>Button</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Device:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="devicesComboBox"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Acceleration speed:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QCheckBox" name="tappingEnabledCheckBox">
+     <property name="text">
+      <string>Single click to activate items</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="naturalScrollingEnabledCheckBox">
+     <property name="text">
+      <string>Natural Scrolling</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="QCheckBox" name="tapToDragEnabledCheckBox">
+     <property name="text">
+      <string>Tap to drag</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDoubleSpinBox" name="accelSpeedDoubleSpinBox">
+     <property name="decimals">
+      <number>2</number>
+     </property>
+     <property name="minimum">
+      <double>-1.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Scrolling:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="noScrollingRadioButton">
+       <property name="text">
+        <string>&amp;Disabled</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="twoFingerScrollingRadioButton">
+       <property name="text">
+        <string>&amp;Two-Finger</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="edgeScrollingRadioButton">
+       <property name="text">
+        <string>Ed&amp;ge</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="buttonScrollingRadioButton">
+       <property name="text">
+        <string>B&amp;utton</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
(1) The name is changed to "Mouse and Touchpad". The "Mouse" section should be either removed or merged with it in future.

(2) The GUI wasn't updated on changing the device. That's fixed by this patch.

(3) The signals are changed so that the slots are called only with user interaction, and not on device change. In the case of the spinbox, `blockSignals()` is called when the value is changed by the code (on device change). The slots are also modified accordingly.

(4) The variable `curDevice` is removed.