### PR TITLE
Apply button for appearance and input config dialogs

### DIFF
--- a/liblxqt-config-cursor/selectwnd.h
+++ b/liblxqt-config-cursor/selectwnd.h
@@ -36,8 +36,13 @@ public:
     SelectWnd (LXQt::Settings* settings, QWidget *parent=0);
     ~SelectWnd ();
 
+    void applyCusorTheme();
+
 public slots:
     void setCurrent ();
+
+signals:
+    void settingsChanged();
 
 protected:
     // void keyPressEvent (QKeyEvent *e);
@@ -46,7 +51,6 @@ private:
     bool iconsIsWritable () const;
     void selectRow (int) const;
     void selectRow (const QModelIndex &index) const { selectRow(index.row()); }
-    void applyCurrent ();
 
 private slots:
     void currentChanged (const QModelIndex &current, const QModelIndex &previous);

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -127,7 +127,7 @@ static bool grep(QFile &file, QByteArray text)
     while (!file.atEnd()) {
         QByteArray line = file.readLine().trimmed();
         if(line.startsWith(text)) {
-            return true;   
+            return true;
         }
     }
     file.close();
@@ -172,7 +172,7 @@ void ConfigOtherToolKits::setXSettingsConfig()
     // then updateConfigFromSettings is not required.
     //updateConfigFromSettings();
     //mConfig.styleTheme = getGTKThemeFromRCFile(version);
-    
+
     // Reload settings. xsettingsd must be installed.
     // xsettingsd settings are written to stdin.
     if(QProcess::Running == mXsettingsdProc.state()) {
@@ -204,14 +204,14 @@ QString ConfigOtherToolKits::getConfig(const char *configString)
 {
     return QString(configString).arg(mConfig.styleTheme, mConfig.iconTheme,
         mConfig.fontName, mConfig.buttonStyle==0 ? "0":"1",
-        mConfig.toolButtonStyle 
+        mConfig.toolButtonStyle
         );
 }
 
 void ConfigOtherToolKits::writeConfig(QString path, const char *configString)
 {
     path = _get_config_path(path);
-    
+
     QFile file(path);
     if(! file.exists()) {
         QFileInfo fileInfo(file);
@@ -258,8 +258,8 @@ QString ConfigOtherToolKits::getGTKThemeFromRCFile(QString version)
                     QList<QByteArray> parts = line.split('=');
                     if(parts.size()>=2) {
                         file.close();
-                        return parts[1].replace('"', "").trimmed(); 
-                    }   
+                        return parts[1].replace('"', "").trimmed();
+                    }
                 }
             }
             file.close();
@@ -282,7 +282,7 @@ QString ConfigOtherToolKits::getGTKThemeFromRCFile(QString version)
                     if(parts.size()>=2) {
                         file.close();
                         return parts[1].trimmed();
-                    }   
+                    }
                 }
             }
             file.close();
@@ -316,16 +316,16 @@ void ConfigOtherToolKits::updateConfigFromSettings()
     QFont font;
     font.fromString(mSettings->value("font").toString());
     // Font name from: https://developer.gnome.org/pango/stable/pango-Fonts.html#pango-font-description-from-string
-    // FAMILY-LIST [SIZE]", where FAMILY-LIST is a comma separated list of families optionally terminated by a comma, 
-    // STYLE_OPTIONS is a whitespace separated list of words where each word describes one of style, variant, weight, stretch, or gravity, and 
-    // SIZE is a decimal number (size in points) or optionally followed by the unit modifier "px" for absolute size. 
+    // FAMILY-LIST [SIZE]", where FAMILY-LIST is a comma separated list of families optionally terminated by a comma,
+    // STYLE_OPTIONS is a whitespace separated list of words where each word describes one of style, variant, weight, stretch, or gravity, and
+    // SIZE is a decimal number (size in points) or optionally followed by the unit modifier "px" for absolute size.
     mConfig.fontName = QString("%1%2%3 %4")
         .arg(font.family())                                 //%1
         .arg(font.style()==QFont::StyleNormal?"":" Italic") //%2
         .arg(font.weight()==QFont::Normal?"":" Bold")       //%3
         .arg(font.pointSize());                             //%4
     mSettings->endGroup();
-    
+
     mConfig.iconTheme = mSettings->value("icon_theme").toString();
     {
         // Tool button style

--- a/lxqt-config-appearance/configothertoolkits.h
+++ b/lxqt-config-appearance/configothertoolkits.h
@@ -48,7 +48,7 @@ public slots:
     void setConfig();
     void setXSettingsConfig();
     void setGTKConfig(QString version, QString theme = QString());
-    
+
 private:
     struct Config {
         QString iconTheme;
@@ -63,7 +63,7 @@ private:
 
     LXQt::Settings *mSettings;
     LXQt::Settings *mConfigAppearanceSettings;
-    
+
     QProcess mXsettingsdProc;
     QTemporaryFile tempFile;
 };

--- a/lxqt-config-appearance/fontsconfig.h
+++ b/lxqt-config-appearance/fontsconfig.h
@@ -48,20 +48,14 @@ public:
     explicit FontsConfig(LXQt::Settings *settings, QSettings *qtSettings, QWidget *parent = 0);
     ~FontsConfig();
 
+    void updateQtFont();
+
 public Q_SLOTS:
     void initControls();
 
 signals:
-    void updateSettings();
-
-private Q_SLOTS:
-    void updateQtFont();
-    void antialiasToggled(bool toggled);
-    void hintingToggled(bool toggled);
-    void subpixelChanged(int index);
-    void hintStyleChanged(int index);
-    void dpiChanged(int value);
-    void autohintToggled(bool toggled);
+    void settingsChanged();
+    void updateOtherSettings();
 
 private:
     Ui::FontsConfig *ui;

--- a/lxqt-config-appearance/iconthemeconfig.h
+++ b/lxqt-config-appearance/iconthemeconfig.h
@@ -44,6 +44,8 @@ public:
     IconThemeConfig(LXQt::Settings *settings, QWidget *parent = 0);
     ~IconThemeConfig();
 
+    void applyIconTheme();
+
 private:
     LXQt::Settings *m_settings;
     void initIconsThemes();
@@ -52,10 +54,8 @@ public slots:
     void initControls();
 
 signals:
-    void updateSettings();
-
-private slots:
-    void iconThemeSelected(QTreeWidgetItem *item, int column);
+    void settingsChanged();
+    void updateOtherSettings();
 };
 
 #endif

--- a/lxqt-config-appearance/lxqtthemeconfig.h
+++ b/lxqt-config-appearance/lxqtthemeconfig.h
@@ -45,11 +45,13 @@ public:
     explicit LXQtThemeConfig(LXQt::Settings *settings, QWidget *parent = 0);
     ~LXQtThemeConfig();
 
+    void applyLxqtTheme();
+
 public slots:
     void initControls();
 
-private slots:
-    void lxqtThemeSelected(QTreeWidgetItem* item, int column);
+signals:
+    void settingsChanged();
 
 private:
     Ui::LXQtThemeConfig *ui;

--- a/lxqt-config-appearance/styleconfig.h
+++ b/lxqt-config-appearance/styleconfig.h
@@ -44,26 +44,21 @@ class StyleConfig : public QWidget
     Q_OBJECT
 
 public:
-    explicit StyleConfig(LXQt::Settings *settings, 
+    explicit StyleConfig(LXQt::Settings *settings,
         QSettings *qtSettings, LXQt::Settings *configAppearanceSettings,
         ConfigOtherToolKits *configOtherToolKits, QWidget *parent = 0);
     ~StyleConfig();
+
+    void applyStyle();
 
 public slots:
     void initControls();
 
 signals:
-    void updateSettings();
+    void settingsChanged();
 
 private slots:
-    void gtk2StyleSelected(const QString &themeName);
-    void gtk3StyleSelected(const QString &themeName);
-    void qtStyleSelected(const QString &themeName);
-    
     void showAdvancedOptions(bool on);
-    
-    void toolButtonStyleSelected(int index);
-    void singleClickActivateToggled(bool toggled);
 
 private:
     Ui::StyleConfig *ui;

--- a/lxqt-config-input/keyboardconfig.h
+++ b/lxqt-config-input/keyboardconfig.h
@@ -36,20 +36,18 @@ public:
   virtual ~KeyboardConfig();
 
   void accept();
+  void applyConfig();
 
 public Q_SLOTS:
   void reset();
+
+Q_SIGNALS:
+    void settingsChanged();
 
 private:
   void setLeftHandedMouse();
   void loadSettings();
   void initControls();
-
-private Q_SLOTS:
-  void onKeyboardSliderChanged(int value);
-  void onKeyboardBeepToggled(bool checked);
-  void onCorsorFlashTimeChanged(int value);
-  void onKeyboardNumLockToggled(bool checked);
 
 private:
   Ui::KeyboardConfig ui;
@@ -59,9 +57,12 @@ private:
   int oldDelay;
   int interval;
   int oldInterval;
+  int flashTime;
+  int oldFlashTime;
   bool beep;
   bool oldBeep;
   bool numlock;
+  bool oldNumlock;
 };
 
 #endif // KEYBOARDCONFIG_H

--- a/lxqt-config-input/keyboardlayoutconfig.h
+++ b/lxqt-config-input/keyboardlayoutconfig.h
@@ -47,13 +47,17 @@ public:
   KeyboardLayoutConfig(LXQt::Settings* _settings, QWidget* parent = 0);
   virtual ~KeyboardLayoutConfig();
 
+  void applyConfig();
+
 public Q_SLOTS:
-  void accept();
   void reset();
   void onAddLayout();
   void onRemoveLayout();
   void onMoveUp();
   void onMoveDown();
+
+Q_SIGNALS:
+    void settingsChanged();
 
 private:
   void loadSettings();
@@ -69,6 +73,7 @@ private:
   QList<QPair<QString, QString> > currentLayouts_;
   QMap<QString, KeyboardLayoutInfo> knownLayouts_;
   LXQt::Settings* settings;
+  bool applyConfig_;
 };
 
 #endif // KEYBOARDLAYOUTCONFIG_H

--- a/lxqt-config-input/mouseconfig.h
+++ b/lxqt-config-input/mouseconfig.h
@@ -36,21 +36,18 @@ public:
   virtual ~MouseConfig();
 
   void accept();
+  void applyConfig();
+
 public Q_SLOTS:
   void reset();
+
+Q_SIGNALS:
+    void settingsChanged();
 
 private:
   void setLeftHandedMouse();
   void loadSettings();
   void initControls();
-
-private Q_SLOTS:
-  void onMouseAccelChanged(int value);
-  void onMouseThresholdChanged(int value);
-  void onMouseLeftHandedToggled(bool checked);
-  void onDoubleClickIntervalChanged(int value);
-  void onWheelScrollLinesChanged(int value);
-  void onSingleClickChanged(bool checked);
 
 private:
   Ui::MouseConfig ui;
@@ -60,6 +57,10 @@ private:
   int oldAccel;
   int threshold;
   int oldThreshold;
+  int doubleClickInterval;
+  int oldDoubleClickInterval;
+  int wheelScrollLines;
+  int oldWheelScrollLines;
   bool leftHanded;
   bool oldLeftHanded;
   bool singleClick;

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -38,21 +38,22 @@ public:
     virtual ~TouchpadConfig();
 
     void accept();
+    void applyConfig();
+
 public Q_SLOTS:
     void reset();
-    void scrollingRadioButtonToggled();
+
+Q_SIGNALS:
+    void settingsChanged();
+
+private:
+    void initControls();
+    void initFeatureControl(QCheckBox* control, int featureEnabled);
 
 private:
     LXQt::Settings* settings;
     Ui::TouchpadConfig ui;
     QList<TouchpadDevice> devices;
-
-    void initControls();
-    void initFeatureControl(QCheckBox* control, int featureEnabled);
-    void setTappingEnabled();
-    void setNaturalScrollingEnabled();
-    void setTapToDragEnabled();
-    void setAccelSpeed(float speed);
 };
 
 #endif


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/1625

Depends on https://github.com/lxqt/liblxqt/pull/202

Since the appearance and input config dialogs had cursor themes in common (which is good, IMO), the patch should have covered both; hence its big size.

Its logic is simple though: When a setting is changed, don't apply it immediately but enable the Apply button for the user (as in KDE). If several settings are changed, the Apply button will save and apply all of them when clicked.

NOTE: Rebasing this PR would be VERY boring to me. Please don't torture me!