### PR TITLE
Fix a typo in the option name

### DIFF
--- a/lxqt-config-brightness/main.cpp
+++ b/lxqt-config-brightness/main.cpp
@@ -34,7 +34,7 @@ int main(int argn, char* argv[])
                                            "\nliblxqt   " LXQT_VERSION
                                            "\nQt        " QT_VERSION_STR);
     app.setApplicationVersion(VERINFO);
-    QCommandLineOption increaseOption(QStringList() << "i" << "icrease",
+    QCommandLineOption increaseOption(QStringList() << "i" << "increase",
             app.tr("Increase brightness."));
     QCommandLineOption decreaseOption(QStringList() << "d" << "decrease",
             app.tr("Decrease brightness."));


### PR DESCRIPTION
As a side note, default keyboard shortcuts use `lxqt-config-brightness -i` so there was no real breakage.

https://github.com/lxqt/lxqt-globalkeys/blob/9ddb15f90edbc1db2d1ebe7ac719f28a7d787e5c/xdg/globalkeyshortcuts.conf#L22-L25