### PR TITLE
List all GTK-3.x themes.

### DIFF
--- a/liblxqt-config-cursor/selectwnd.cpp
+++ b/liblxqt-config-cursor/selectwnd.cpp
@@ -181,7 +181,7 @@ void SelectWnd::applyCusorTheme()
     mSettings->setValue("cursor_theme", theme->name());
     mSettings->endGroup();
 
-    // The XCURSOR_THEME environment varialbe does not work sometimes.
+    // The XCURSOR_THEME environment variable does not work sometimes.
     // Besides, XDefaults values are not used by Qt.
     // So, let's write the new theme name to ~/.icons/default/index.theme.
     // This is the most reliable way.

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -230,6 +230,11 @@ QStringList ConfigOtherToolKits::getGTKThemes(QString version)
 {
     QStringList themeList;
     QString configFile = version=="2.0" ? "gtkrc" : "gtk.css";
+    
+    if(version != "2.0") {
+        // Insert default GTK3 themes:
+        themeList << "Adwaita" << "HighContrast" << "HighContrastInverse";
+    }
 
     QStringList dataPaths = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
     for(QString dataPath : dataPaths) {

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -47,6 +47,7 @@ gtk-font-name = "%3"
 gtk-button-images = %4
 gtk-menu-images = %4
 gtk-toolbar-style = %5
+gtk-cursor-theme-name = %6
 )GTK2_CONFIG";
 
 static const char *GTK3_CONFIG = R"GTK3_CONFIG(
@@ -59,6 +60,7 @@ gtk-font-name = %3
 gtk-menu-images = %4
 gtk-button-images = %4
 gtk-toolbar-style = %5
+gtk-cursor-theme-name = %6
 )GTK3_CONFIG";
 
 static const char *XSETTINGS_CONFIG = R"XSETTINGS_CONFIG(
@@ -69,6 +71,7 @@ Gtk/FontName "%3"
 Gtk/MenuImages %4
 Gtk/ButtonImages %4
 Gtk/ToolbarStyle "%5"
+Gtk/CursorThemeName "%6"
 )XSETTINGS_CONFIG";
 
 ConfigOtherToolKits::ConfigOtherToolKits(LXQt::Settings *settings,  LXQt::Settings *configAppearanceSettings, QObject *parent) : QObject(parent)
@@ -202,9 +205,12 @@ void ConfigOtherToolKits::setGTKConfig(QString version, QString theme)
 
 QString ConfigOtherToolKits::getConfig(const char *configString)
 {
+    LXQt::Settings* sessionSettings = new LXQt::Settings("session");
+    QString mouseStyle = sessionSettings->value("Mouse/cursor_theme").toString();
+    delete sessionSettings;
     return QString(configString).arg(mConfig.styleTheme, mConfig.iconTheme,
         mConfig.fontName, mConfig.buttonStyle==0 ? "0":"1",
-        mConfig.toolButtonStyle
+        mConfig.toolButtonStyle, mouseStyle
         );
 }
 

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -229,16 +229,24 @@ void ConfigOtherToolKits::writeConfig(QString path, const char *configString)
 QStringList ConfigOtherToolKits::getGTKThemes(QString version)
 {
     QStringList themeList;
-    QString configFile = version=="2.0" ? "gtk-2.0/gtkrc" : QString("gtk-%1/gtk.css").arg(version);
+    QString configFile = version=="2.0" ? "gtkrc" : "gtk.css";
 
     QStringList dataPaths = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
     for(QString dataPath : dataPaths) {
         QDir themesPath(dataPath + "/themes");
         QStringList themes = themesPath.entryList(QDir::Dirs);
         for(QString theme : themes) {
-            QFileInfo themePath(QString("%1/themes/%2/%3").arg(dataPath, theme, configFile));
-            if(themePath.exists())
-                themeList.append(theme);
+            QDir dirsInTheme(QString("%1/themes/%2").arg(dataPath, theme));
+            QStringList dirs = dirsInTheme.entryList(QDir::Dirs);
+            for(QString dir : dirs) {
+                if(dir.startsWith("gtk-")) {
+                    if(!version.endsWith("*") && dir != QString("gtk-%1").arg(version))
+                         continue;
+                    QFileInfo themePath(QString("%1/themes/%2/%3/%4").arg(dataPath, theme, dir, configFile));
+                    if(themePath.exists() && !themeList.contains(theme))
+                         themeList.append(theme);
+                }
+            }
         }
     }
     return themeList;

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -112,11 +112,11 @@ int main (int argc, char **argv)
     QObject::connect(dialog, &LXQt::ConfigDialog::clicked, [=] (QDialogButtonBox::StandardButton btn) {
         if (btn == QDialogButtonBox::Apply)
         {
-            stylePage->applyStyle();
             iconPage->applyIconTheme();
             themePage->applyLxqtTheme();
             fontsPage->updateQtFont();
             cursorPage->applyCusorTheme();
+            stylePage->applyStyle(); // Cursor and font have to be set before style
             // disable Apply button after changes are applied
             dialog->enableButton(btn, false);
         }

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -144,22 +144,15 @@ void StyleConfig::applyStyle()
     }
 
     // GTK3
-    bool setXSettings = false;
     themeName = ui->gtk3ComboBox->currentText();
-    if(themeName != mConfigOtherToolKits->getGTKThemeFromRCFile("3.0")) {
-        mConfigOtherToolKits->setGTKConfig("3.0", themeName);
-        setXSettings = true;
-    }
+    mConfigOtherToolKits->setGTKConfig("3.0", themeName);
 
     // GTK2
     themeName = ui->gtk2ComboBox->currentText();
-    if(themeName != mConfigOtherToolKits->getGTKThemeFromRCFile("2.0")) {
-        mConfigOtherToolKits->setGTKConfig("2.0", themeName);
-        setXSettings = true;
-    }
-
-    if(setXSettings)
-        mConfigOtherToolKits->setXSettingsConfig();
+    mConfigOtherToolKits->setGTKConfig("2.0", themeName);
+    
+    // Update xsettingsd
+    mConfigOtherToolKits->setXSettingsConfig();
 }
 
 void StyleConfig::showAdvancedOptions(bool on)

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -76,7 +76,7 @@ void StyleConfig::initControls()
     // Fill global themes
     QStringList qtThemes = QStyleFactory::keys();
     QStringList gtk2Themes = mConfigOtherToolKits->getGTKThemes("2.0");
-    QStringList gtk3Themes = mConfigOtherToolKits->getGTKThemes("3.0");
+    QStringList gtk3Themes = mConfigOtherToolKits->getGTKThemes("3.*");
 
     if(!mConfigAppearanceSettings->contains("ControlGTKThemeEnabled"))
         mConfigAppearanceSettings->setValue("ControlGTKThemeEnabled", false);


### PR DESCRIPTION
There are GTK-3 themes that are not listed by lxqt-config-appearance. lxqt-config-appearance was showing gtk-3.0 themes by default. Now, all gtk-3.x versions are shown.

Cursor style is also saved.