### PR TITLE
Apply GTK settings only if the user chooses that

### DIFF
--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -143,16 +143,17 @@ void StyleConfig::applyStyle()
         mConfigOtherToolKits->setConfig();
     }
 
-    // GTK3
-    themeName = ui->gtk3ComboBox->currentText();
-    mConfigOtherToolKits->setGTKConfig(QStringLiteral("3.0"), themeName);
-
-    // GTK2
-    themeName = ui->gtk2ComboBox->currentText();
-    mConfigOtherToolKits->setGTKConfig(QStringLiteral("2.0"), themeName);
-    
-    // Update xsettingsd
-    mConfigOtherToolKits->setXSettingsConfig();
+    if (ui->advancedOptionsGroupBox->isChecked())
+    {
+        // GTK3
+        themeName = ui->gtk3ComboBox->currentText();
+        mConfigOtherToolKits->setGTKConfig(QStringLiteral("3.0"), themeName);
+        // GTK2
+        themeName = ui->gtk2ComboBox->currentText();
+        mConfigOtherToolKits->setGTKConfig(QStringLiteral("2.0"), themeName);
+        // Update xsettingsd
+        mConfigOtherToolKits->setXSettingsConfig();
+    }
 }
 
 void StyleConfig::showAdvancedOptions(bool on)


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-config/issues/508

Changing GTK settings is optional in the GUI; so, they shouldn't be overwritten if the user doesn't want that.

As to why changing GTK settings should remain optional, suffice it to say that the user may have a GTK-based DE installed alongside LXQt, although that isn't the only reason.