### PR TITLE
Add option to scale widgets to double size

### DIFF
--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
     QSettings& qtSettings = *settings; // use lxqt config file for Qt settings in Qt5.
 
     /*** Widget Style ***/
-    StyleConfig* stylePage = new StyleConfig(settings, &qtSettings, &mConfigAppearanceSettings, configOtherToolKits, dialog);
+    StyleConfig* stylePage = new StyleConfig(settings, &qtSettings, &mConfigAppearanceSettings, configOtherToolKits, sessionSettings, dialog);
     dialog->addPage(stylePage, QObject::tr("Widget Style"), QStringList() << QStringLiteral("preferences-desktop-theme") << QStringLiteral("preferences-desktop"));
     QObject::connect(dialog, &LXQt::ConfigDialog::reset, stylePage, &StyleConfig::initControls);
     QObject::connect(stylePage, &StyleConfig::settingsChanged, dialog, [dialog] {

--- a/lxqt-config-appearance/styleconfig.h
+++ b/lxqt-config-appearance/styleconfig.h
@@ -46,7 +46,8 @@ class StyleConfig : public QWidget
 public:
     explicit StyleConfig(LXQt::Settings *settings,
         QSettings *qtSettings, LXQt::Settings *configAppearanceSettings,
-        ConfigOtherToolKits *configOtherToolKits, QWidget *parent = 0);
+        ConfigOtherToolKits *configOtherToolKits,
+        LXQt::Settings *sessionSettings, QWidget *parent = 0);
     ~StyleConfig();
 
     void applyStyle();
@@ -65,7 +66,9 @@ private:
     QSettings *mQtSettings;
     LXQt::Settings *mSettings;
     LXQt::Settings *mConfigAppearanceSettings;
+    LXQt::Settings *mSessionSettings;
     ConfigOtherToolKits *mConfigOtherToolKits;
+    bool mScaleVariablesSetBefore;
 };
 
 #endif // STYLECONFIG_H

--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -136,6 +136,21 @@ Make sure 'xsettingsd' is installed to help GTK applications apply themes on the
      </property>
     </widget>
    </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="scaleCheckBox">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;
+· Window titles need to be scaled separately under &lt;strong&gt;Font &amp;gt; Resolution (DPI)&lt;/strong&gt;&lt;br/&gt;
+· This scaling option does not currently support GTK2 applications, or applications run as the super user (root)&lt;br/&gt;
+· Enabling this options will set environment variables under &lt;strong&gt;Session Settings &amp;gt; Environment (Advanced)&lt;/strong&gt;&lt;br/&gt;
+· Controls at the top-right of a window can be set with custom themes under &lt;strong&gt;Openbox Settings &amp;gt; Theme&lt;/strong&gt;
+&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Scale to double size, for high DPI screens (hover for notes)</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="qtComboBox"/>
    </item>


### PR DESCRIPTION
Selecting this option is a shortcut which adds/sets the following environment variables (under Session Settings > Environment (Advanced)),
- QT_SCALE_FACTOR=2
- QT_AUTO_SCREEN_SCALE_FACTOR=0 (to stop HiDPI Qt apps like Qt Designer from scaling twice)
- GDK_SCALE=2
- XCURSOR_SIZE=32
as described in this thread https://forum.lxqt.org/t/detailed-guide-to-enable-high-dpi-scaling-on-lxqt/507