### PR TITLE
lxqt-config-monitor: Fix command line options warnings

### DIFF
--- a/lxqt-config-monitor/main.cpp
+++ b/lxqt-config-monitor/main.cpp
@@ -60,8 +60,6 @@ int main(int argc, char** argv)
     QCommandLineOption loadOption(QStringList() << QStringLiteral("l") << QStringLiteral("loadlast"),
             app.tr("Load last settings."));
     parser.addOption(loadOption);
-    QCommandLineOption helpOption = parser.addHelpOption();
-    parser.addOption(loadOption);
     parser.addVersionOption();
     parser.addHelpOption();
 


### PR DESCRIPTION
Some options are being added to the parser two times.