### PR TITLE
Removed old mouse accel/sensitivity options

### DIFF
--- a/lxqt-config-input/mouseconfig.cpp
+++ b/lxqt-config-input/mouseconfig.cpp
@@ -59,10 +59,6 @@ MouseConfig::MouseConfig(LXQt::Settings* _settings, QSettings* _qtSettings, QWid
   loadSettings();
   initControls();
 
-  // set_range_stops(ui.mouseAccel, 10);
-  connect(ui.mouseAccel, &QAbstractSlider::valueChanged, this, &MouseConfig::settingsChanged);
-  // set_range_stops(ui.mouseThreshold, 10);
-  connect(ui.mouseThreshold, &QAbstractSlider::valueChanged, this, &MouseConfig::settingsChanged);
   connect(ui.mouseLeftHanded, &QAbstractButton::clicked, this, &MouseConfig::settingsChanged);
   connect(ui.doubleClickInterval, QOverload<int>::of(&QSpinBox::valueChanged), this, &MouseConfig::settingsChanged);
   connect(ui.wheelScrollLines, QOverload<int>::of(&QSpinBox::valueChanged), this, &MouseConfig::settingsChanged);
@@ -73,14 +69,6 @@ MouseConfig::~MouseConfig() {
 }
 
 void MouseConfig::initControls() {
-  ui.mouseAccel->blockSignals(true);
-  ui.mouseAccel->setValue(accel);
-  ui.mouseAccel->blockSignals(false);
-
-  ui.mouseThreshold->blockSignals(true);
-  ui.mouseThreshold->setValue(110 - threshold);
-  ui.mouseThreshold->blockSignals(false);
-
   ui.mouseLeftHanded->setChecked(leftHanded);
 
   ui.singleClick->setChecked(singleClick);
@@ -138,23 +126,6 @@ void MouseConfig::applyConfig()
 {
   bool acceptSetting = false;
   bool applyX11 = false;
-
-  if(accel != ui.mouseAccel->value())
-  {
-    accel = ui.mouseAccel->value();
-    XChangePointerControl(QX11Info::display(), True, False,
-                            accel, 10, 0);
-    acceptSetting = true;
-  }
-
-  /* threshold = 110 - sensitivity. The lower the threshold, the higher the sensitivity */
-  if(threshold != 110 - ui.mouseThreshold->value())
-  {
-    threshold = 110 - ui.mouseThreshold->value();
-    XChangePointerControl(QX11Info::display(), False, True,
-                            0, 10, threshold);
-    acceptSetting = true;
-  }
 
   if(leftHanded != ui.mouseLeftHanded->isChecked())
   {

--- a/lxqt-config-input/mouseconfig.ui
+++ b/lxqt-config-input/mouseconfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>324</width>
-    <height>223</height>
+    <height>123</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,117 +24,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox_5">
-     <property name="title">
-      <string>Motion</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="1" column="3">
-       <widget class="QLabel" name="label_35">
-        <property name="text">
-         <string>High</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_36">
-        <property name="text">
-         <string>Fast</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_37">
-        <property name="text">
-         <string>Sensitivity:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="label_38">
-        <property name="text">
-         <string>Low</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QSlider" name="mouseThreshold">
-        <property name="minimum">
-         <number>10</number>
-        </property>
-        <property name="maximum">
-         <number>110</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="tickPosition">
-         <enum>QSlider::TicksAbove</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_39">
-        <property name="text">
-         <string>Acceleration:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QSlider" name="mouseAccel">
-        <property name="minimum">
-         <number>10</number>
-        </property>
-        <property name="maximum">
-         <number>110</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="tickPosition">
-         <enum>QSlider::TicksAbove</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_40">
-        <property name="text">
-         <string>Slow</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QLabel" name="label_41">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="QLabel" name="label_42">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Double click interval:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="3" column="1">
     <widget class="QSpinBox" name="doubleClickInterval">
      <property name="suffix">
       <string> ms</string>
@@ -144,65 +41,32 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Wheel scroll lines:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="4" column="1">
     <widget class="QSpinBox" name="wheelScrollLines"/>
    </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="mouseLeftHanded">
-     <property name="text">
-      <string>Left handed (Swap left and right mouse buttons)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QCheckBox" name="singleClick">
      <property name="text">
       <string>Single click to activate items</string>
      </property>
     </widget>
    </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="mouseLeftHanded">
+     <property name="text">
+      <string>Left handed (Swap left and right mouse buttons)</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>mouseAccel</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>label_41</receiver>
-   <slot>setNum(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>175</x>
-     <y>74</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>342</x>
-     <y>73</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mouseThreshold</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>label_42</receiver>
-   <slot>setNum(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>191</x>
-     <y>95</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>347</x>
-     <y>95</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
They had no effect and were confusing. The real options are under "Mouse and Touchpad".

NOTE: Later, we could discuss how to rearrange the dialog's sections but, IMHO, those options should have been removed as soon as possible.