### PR TITLE
Fix warnings when applying settings in lxqt-config-monitor

### DIFF
--- a/lxqt-config-monitor/timeoutdialog.cpp
+++ b/lxqt-config-monitor/timeoutdialog.cpp
@@ -62,7 +62,7 @@ void TimeoutDialog::onTimeout()
     else
     {
         int remaining = maximum / TIMER_DURATION - TIMER_DURATION * time / maximum;
-        ui.remainingTime->setText(tr("%n second(s) remaining", nullptr, remaining).arg(remaining));
+        ui.remainingTime->setText(tr("%n second(s) remaining", nullptr, remaining));
         ui.progressBar->setValue(time);
     }
 }


### PR DESCRIPTION
The following warnings appeared after clicking Apply in
lxqt-config-monitor:

QString::arg: Argument missing: "10 second(s) remaining" , 10
QString::arg: Argument missing: "9 second(s) remaining" , 9
QString::arg: Argument missing: "8 second(s) remaining" , 8
QString::arg: Argument missing: "7 second(s) remaining" , 7
QString::arg: Argument missing: "6 second(s) remaining" , 6
QString::arg: Argument missing: "5 second(s) remaining" , 5
QString::arg: Argument missing: "4 second(s) remaining" , 4
QString::arg: Argument missing: "3 second(s) remaining" , 3
QString::arg: Argument missing: "2 second(s) remaining" , 2
QString::arg: Argument missing: "1 second(s) remaining" , 1

Per Qt docs [1], %n is already replaced by tr(), so arg() is not needed.
Not sure if tr() has been changed or not, but this is already the case
in Qt 4 [2].

[1] https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals
[2] https://doc.qt.io/archives/qt-4.8/i18n-source-translation.html#handling-plurals