### PR TITLE
lxqt-config-appearance: Fix widget style chooser alignment

### DIFF
--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -136,16 +136,6 @@ Make sure 'xsettingsd' is installed to help GTK applications apply themes on the
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="qtComboBox"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Qt Style</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="2">
     <layout class="QFormLayout" name="formLayout_3">
      <property name="horizontalSpacing">
@@ -157,19 +147,29 @@ Make sure 'xsettingsd' is installed to help GTK applications apply themes on the
      <property name="bottomMargin">
       <number>10</number>
      </property>
-     <item row="0" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
         <string>Window Color:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="1" column="1">
       <widget class="ColorLabel" name="winColorLabel">
        <property name="text">
         <string/>
        </property>
       </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Qt Style</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="qtComboBox"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Make the label and combobox, position aligment and size behave.
Simply put them inside a layout.