### PR TITLE
Fix a crash due to 'output->currentMode()' being null sometimes

### DIFF
--- a/lxqt-config-monitor/kscreenutils.cpp
+++ b/lxqt-config-monitor/kscreenutils.cpp
@@ -17,11 +17,14 @@ void KScreenUtils::updateScreenSize(KScreen::ConfigPtr &config)
         if( !output->isConnected() )
             continue;
         QPoint pos = output->pos();
-        KScreen::ModePtr mode(output->currentMode());
-        width = qMax(pos.x() + mode->size().width(), width);
-        height = qMax(pos.y() + mode->size().height(), height);
+        if (output->currentMode()) {
+            KScreen::ModePtr mode(output->currentMode());
+            width = qMax(pos.x() + mode->size().width(), width);
+            height = qMax(pos.y() + mode->size().height(), height);
+        }
     }
-    config->screen()->setCurrentSize(QSize(width, height));
+    if (width != 0 && height != 0)
+        config->screen()->setCurrentSize(QSize(width, height));
 }
 
 

--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -178,9 +178,11 @@ void MonitorSettingsDialog::saveConfiguration(KScreen::ConfigPtr config)
             monitor.xPos = output->pos().x();
             monitor.yPos = output->pos().y();
             monitor.currentMode = output->currentModeId();
-            monitor.currentModeWidth = output->currentMode()->size().width();
-            monitor.currentModeHeight = output->currentMode()->size().height();
-            monitor.currentModeRate = output->currentMode()->refreshRate();
+            if (output->currentMode()) {
+                monitor.currentModeWidth = output->currentMode()->size().width();
+                monitor.currentModeHeight = output->currentMode()->size().height();
+                monitor.currentModeRate = output->currentMode()->refreshRate();
+            }
             monitor.rotation = output->rotation();
         }
         currentSettings.append(monitor);


### PR DESCRIPTION
Hello,
I happen to happily use LXQT for a while now. However attempting to save my monitor settings always results in a crash of lxqt-config-monitor. I have to restore things manually every time I boot my computer, which is pretty annoying. FYI I'm using an external HDMI monitor connected to a laptop.
I have forked the code, rebuilt it in debug mode, and backtraced the crash.
Hope this can help a bit.
Best regards.