### PR TITLE
Fixed type associations and added "Default Application"

### DIFF
--- a/lxqt-config-file-associations/applicationchooser.h
+++ b/lxqt-config-file-associations/applicationchooser.h
@@ -36,10 +36,13 @@ class ApplicationChooser : public QDialog
 {
     Q_OBJECT
 public:
-    ApplicationChooser(const XdgMimeType& mimeInfo, bool showUseAlwaysCheckBox = false);
+    ApplicationChooser(const QString& type, bool showUseAlwaysCheckBox = false);
 
     virtual ~ApplicationChooser();
-    XdgDesktopFile* DefaultApplication() const { return m_CurrentDefaultApplication; }
+
+    XdgDesktopFile* DefaultApplication() const {
+        return m_CurrentDefaultApplication; // should be deleted by the caller
+    }
 
     virtual int exec();
 
@@ -53,9 +56,10 @@ private:
     void addApplicationsToApplicationListWidget(QTreeWidgetItem* parent,
                                                 QList<XdgDesktopFile*> applications,
                                                 QSet<XdgDesktopFile*> & alreadyAdded);
-    XdgMimeType m_MimeInfo;
+    QString m_Type;
     Ui::ApplicationChooser widget;
     XdgDesktopFile* m_CurrentDefaultApplication;
+    QSet<XdgDesktopFile*> allApps; // all app pointers that should be deleted in d-tor
 };
 
 #endif	/* _APPLICATIONCHOOSER_H */

--- a/lxqt-config-file-associations/mimetypedata.h
+++ b/lxqt-config-file-associations/mimetypedata.h
@@ -42,6 +42,10 @@ public:
     QString inline patterns() const { return mPatterns; };
     QString inline comment() const { return mComment; };
 
+    void setName(const QString name) {
+        mName = name;
+    }
+
     bool matches(const QString& filter) const;
 
 private:

--- a/lxqt-config-file-associations/mimetypeviewer.h
+++ b/lxqt-config-file-associations/mimetypeviewer.h
@@ -29,6 +29,7 @@
 
 #include <QDialog>
 #include <QStringList>
+#include <QTemporaryFile>
 
 #include <XdgMimeType>
 
@@ -48,20 +49,21 @@ public:
     virtual ~MimetypeViewer();
 
 private slots:
-    void initializeMimetypeTreeView();
     void currentMimetypeChanged();
     void filter(const QString&);
     void chooseApplication();
     void dialogButtonBoxClicked(QAbstractButton *button);
 
 private:
+    XdgDesktopFile* chooseApp(const QString& type);
+    void initializeMimetypeTreeView();
+    void updateDefaultApplications();
     void addSearchIcon();
     void loadAllMimeTypes();
-    XdgMimeType m_CurrentMime;
-    QSettings* mDefaultsList;
-    LXQt::SettingsCache *mSettingsCache;
+    QString m_CurrentType;
     Ui::mimetypeviewer widget;
     QStringList mediaTypes;
+    QTemporaryFile mMimeappsTemp, mDEMimeappsTemp; // for resetting all settings
     QList <QTreeWidgetItem*> mItemList;
     QMap<QString, QTreeWidgetItem *> mGroupItems;
 };

--- a/lxqt-config-file-associations/mimetypeviewer.ui
+++ b/lxqt-config-file-associations/mimetypeviewer.ui
@@ -7,269 +7,523 @@
     <x>0</x>
     <y>0</y>
     <width>565</width>
-    <height>370</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>530</width>
-    <height>370</height>
+    <height>400</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>File Associations</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="1" rowspan="2">
-    <widget class="QFrame" name="mimeFrame">
-     <property name="enabled">
-      <bool>true</bool>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>280</width>
-       <height>260</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <widget class="QGroupBox" name="applicationsGroupBox">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>170</y>
-        <width>260</width>
-        <height>140</height>
-       </rect>
-      </property>
-      <property name="title">
-       <string>Default application</string>
-      </property>
-      <widget class="QPushButton" name="chooseApplicationsButton">
-       <property name="geometry">
-        <rect>
-         <x>140</x>
-         <y>90</y>
-         <width>110</width>
-         <height>30</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>&amp;Choose...</string>
-       </property>
-      </widget>
-      <widget class="QFrame" name="applicationLabelFrame">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>20</y>
-         <width>241</width>
-         <height>51</height>
-        </rect>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="appIcon">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>TextLabel</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="applicationLabel">
-          <property name="text">
-           <string>None</string>
-          </property>
-          <property name="indent">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-     <widget class="QGroupBox" name="patternsGroupBox">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>100</y>
-        <width>260</width>
-        <height>60</height>
-       </rect>
-      </property>
-      <property name="title">
-       <string>Patterns</string>
-      </property>
-      <widget class="QLabel" name="patternsLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>20</y>
-         <width>230</width>
-         <height>30</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>*.txt *.xml</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </widget>
-     <widget class="QGroupBox" name="mimetypeGroupBox">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>0</y>
-        <width>260</width>
-        <height>90</height>
-       </rect>
-      </property>
-      <property name="title">
-       <string>MIME type</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QLabel" name="iconLabel">
+     <widget class="QWidget" name="tab_1">
+      <attribute name="title">
+       <string>Associations</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLineEdit" name="searchTermLineEdit">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QTreeWidget" name="mimetypeTreeWidget">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="minimumSize">
           <size>
-           <width>50</width>
-           <height>50</height>
+           <width>180</width>
+           <height>0</height>
           </size>
          </property>
-         <property name="text">
-          <string>Icon</string>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="descriptionLabel">
-         <property name="text">
-          <string>Description</string>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
          </property>
-         <property name="wordWrap">
+         <property name="headerHidden">
           <bool>true</bool>
          </property>
+         <property name="expandsOnDoubleClick">
+          <bool>false</bool>
+         </property>
+         <property name="columnCount">
+          <number>0</number>
+         </property>
+         <attribute name="headerVisible">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="headerDefaultSectionSize">
+          <number>500</number>
+         </attribute>
+        </widget>
+       </item>
+       <item row="0" column="1" rowspan="2">
+        <widget class="QFrame" name="mimeFrame">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>280</width>
+           <height>260</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_1">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QScrollArea" name="scrollArea_2">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents_3">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>280</width>
+               <height>314</height>
+              </rect>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <property name="spacing">
+               <number>10</number>
+              </property>
+              <item>
+               <widget class="QGroupBox" name="mimetypeGroupBox">
+                <property name="title">
+                 <string>MIME type</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout">
+                 <item>
+                  <widget class="QLabel" name="iconLabel">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>48</width>
+                     <height>48</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Icon</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="descriptionLabel">
+                   <property name="text">
+                    <string>Description</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="indent">
+                    <number>10</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="patternsGroupBox">
+                <property name="title">
+                 <string>Patterns</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_1">
+                 <item>
+                  <widget class="QLabel" name="patternsLabel">
+                   <property name="text">
+                    <string>*.txt *.xml</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="applicationsGroupBox">
+                <property name="title">
+                 <string>Default application</string>
+                </property>
+                <layout class="QGridLayout" name="gridLayout_1">
+                 <item row="0" column="0">
+                  <widget class="QFrame" name="applicationLabelFrame">
+                   <property name="frameShape">
+                    <enum>QFrame::NoFrame</enum>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Raised</enum>
+                   </property>
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <property name="spacing">
+                     <number>0</number>
+                    </property>
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="appIcon">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>48</width>
+                        <height>48</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>Icon</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="applicationLabel">
+                      <property name="text">
+                       <string>None</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>true</bool>
+                      </property>
+                      <property name="indent">
+                       <number>10</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" alignment="Qt::AlignRight">
+                  <widget class="QPushButton" name="chooseApplicationsButton">
+                   <property name="text">
+                    <string>&amp;Choose...</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>5</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Default Applications</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>106</width>
+            <height>231</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="spacing">
+            <number>5</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QGroupBox" name="browserGroupBox">
+             <property name="title">
+              <string>Browser</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_2">
+              <item row="0" column="0">
+               <widget class="QFrame" name="browserLabelFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="browserIcon">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>48</width>
+                     <height>48</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Icon</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="browserLabel">
+                   <property name="text">
+                    <string>None</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="indent">
+                    <number>10</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="1" column="0" alignment="Qt::AlignRight">
+               <widget class="QPushButton" name="chooseBrowserButton">
+                <property name="text">
+                 <string>&amp;Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="emailClientGroupBox">
+             <property name="title">
+              <string>Email Client</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <item row="0" column="0">
+               <widget class="QFrame" name="emailClientLabelFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="emailClientIcon">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>48</width>
+                     <height>48</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Icon</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="emailClientLabel">
+                   <property name="text">
+                    <string>None</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="indent">
+                    <number>10</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="1" column="0" alignment="Qt::AlignRight">
+               <widget class="QPushButton" name="chooseEmailClientButton">
+                <property name="text">
+                 <string>&amp;Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>5</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
      </widget>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLineEdit" name="searchTermLineEdit">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
+   <item>
     <widget class="QDialogButtonBox" name="dialogButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QTreeWidget" name="mimetypeTreeWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>180</width>
-       <height>275</height>
-      </size>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="headerHidden">
-      <bool>true</bool>
-     </property>
-     <property name="expandsOnDoubleClick">
-      <bool>false</bool>
-     </property>
-     <property name="columnCount">
-      <number>0</number>
-     </property>
-     <attribute name="headerVisible">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="headerDefaultSectionSize">
-      <number>500</number>
-     </attribute>
-    </widget>
-   </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>searchTermLineEdit</tabstop>
-  <tabstop>mimetypeTreeWidget</tabstop>
-  <tabstop>chooseApplicationsButton</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This is a relatively big code change:

 1. Scheme protocols are added to the end of associations list.
 2. A tab for default apps is added. For now, it supports the default browser and email client.
 3. Default associations are done in a DE-specific way, so that they don't affect other DEs.
 4. The current changes can be undone correctly and reliably.
 5. The deprecated class `XdgDesktopFileCache` and the inefficient class `LXQt::SettingsCache` are removed from the code. `XdgMimeApps` is used instead of the former. The latter had bugs and couldn't do a correct and clean resetting; `QTemporaryFile` is used instead of it.
 6. All memory leaks are fixed. They were found both by rereading the code and by using `valgrind`.

NOTE 1: The patch relies on the latest git `libqtxdg` and SHOULD NOT be used without it.

NOTE 2: `lxqt-config-file-associations` only supports setting of default apps. The support for removing/sorting associations is still missing. Association removal is supported by `libqtxdg` → `XdgMimeApps` and sorting can be added to it.

Closes https://github.com/lxqt/lxqt/issues/1513