### PR TITLE
Better look for color label in lxqt-config-appearance

### DIFF
--- a/lxqt-config-appearance/colorLabel.h
+++ b/lxqt-config-appearance/colorLabel.h
@@ -44,10 +44,11 @@ signals:
     void colorChanged();
 
 protected:
-    void mousePressEvent(QMouseEvent* event);
+    void mousePressEvent(QMouseEvent* event) override;
+    void paintEvent (QPaintEvent* event) override;
 
 private:
-    QColor stylesheetColor_;
+    QColor color_;
 };
 
 #endif // COLORLABEL_H


### PR DESCRIPTION
The label is painted as the color label of `QColorDialog`, without using style sheets. This way, its look is more professional and consistent with the widget style.