### PR TITLE
add xinput driver detection for touchpad devices

### DIFF
--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -86,8 +86,8 @@ void TouchpadConfig::initControls()
               "LXQt only supports \"libinput\" as xinput driver.\n"
               "(current value: %1)\n"
               "\n"
-              "Check your xinput configuration (/etc/X11/xorg.conf.d).\n"
-              "If not needed, also remove the xf86-input-synaptics package.")
+              "If this is intended, please configure xinput manually.\n"
+              "Otherwise you can get rid of this message by changing xinput driver to \"libinput\".\n")
             .arg(device.xinputDriver()));
       ui.deviceInfoLabel->setStyleSheet(QStringLiteral("background-color: #f88; border-color: #f33; border-size: 1px"));
     };

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -79,6 +79,21 @@ void TouchpadConfig::initControls()
     initFeatureControl(ui.naturalScrollingEnabledCheckBox, device.naturalScrollingEnabled());
     initFeatureControl(ui.tapToDragEnabledCheckBox, device.tapToDragEnabled());
 
+    auto ok = device.xinputDriverSupported();
+    if (!ok) {
+      ui.deviceInfoLabel->setText(
+            tr(
+              "LXQT only supports \"libinput\" as xinput driver.\n"
+              "(current value: %1)\n"
+              "\n"
+              "Check your xinput device configuration (/etc/X11/xorg.conf.d).\n"
+              "If not needed, also remove the xf86-input-synatics package.")
+            .arg(device.xinputDriver()));
+      ui.deviceInfoLabel->setStyleSheet(QStringLiteral("background-color: #f88; border-color: #f33; border-size: 1px"));
+    };
+    ui.deviceInfoLabel->setVisible(!ok);
+    ui.deviceInfoLabel->setFrameStyle(QFrame::Panel | QFrame::Sunken);
+
     float accelSpeed = device.accelSpeed();
     if (!std::isnan(accelSpeed)) {
         ui.accelSpeedDoubleSpinBox->setEnabled(true);

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -83,11 +83,11 @@ void TouchpadConfig::initControls()
     if (!ok) {
       ui.deviceInfoLabel->setText(
             tr(
-              "LXQT only supports \"libinput\" as xinput driver.\n"
+              "LXQt only supports \"libinput\" as xinput driver.\n"
               "(current value: %1)\n"
               "\n"
-              "Check your xinput device configuration (/etc/X11/xorg.conf.d).\n"
-              "If not needed, also remove the xf86-input-synatics package.")
+              "Check your xinput configuration (/etc/X11/xorg.conf.d).\n"
+              "If not needed, also remove the xf86-input-synaptics package.")
             .arg(device.xinputDriver()));
       ui.deviceInfoLabel->setStyleSheet(QStringLiteral("background-color: #f88; border-color: #f33; border-size: 1px"));
     };

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -139,6 +139,13 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="deviceInfoLabel">
+     <property name="text">
+      <string>DeviceInfoLabel</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -201,6 +201,7 @@ QList<TouchpadDevice> TouchpadDevice::enumerate_from_udev()
             if(dev.find_xi2_device())
             {
                 qDebug() << "Detected" << dev.m_name << "on" << dev.devnode;
+                qDebug() << "xinput driver:" << dev.xinputDriver();
                 dev.m_oldTappingEnabled = dev.tappingEnabled();
                 dev.m_oldNaturalScrollingEnabled = dev.naturalScrollingEnabled();
                 dev.m_oldTapToDragEnabled = dev.tapToDragEnabled();
@@ -234,6 +235,17 @@ bool TouchpadDevice::find_xi2_device()
         {
             m_name = QString::fromUtf8(info[i].name);
             deviceid = info[i].deviceid;
+
+            // init xinput driver name
+            auto xi_driver_prop = xi2_get_device_property(deviceid, "Synaptics Capabilities");
+            if (xi_driver_prop.size()) {
+              // lxqt does not support xf86-input-synaptics properties
+              m_xinputDriver = QStringLiteral("synaptics");
+            } else {
+              // otherweise we assumge libinput and don't test on libinput properties
+              m_xinputDriver = QStringLiteral("libinput");
+            }
+
             found = true;
             break;
         }

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -133,7 +133,7 @@ static bool xi2_set_device_property(int deviceid, const char* prop, QList<QVaria
             }
         }
         break;
-    case QMetaType::Float:
+    case QVariant::Double:
         Q_ASSERT(act_type == XInternAtom(dpy, "FLOAT", False));
         Q_ASSERT(act_format == 32);
         float_data = new float[values.size()];

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -49,7 +49,8 @@ public:
 
     const QString& name() const { return m_name; }
     QString escapedName() const;
-    QString xinputDriver() const { return m_xinputDriver; }
+    auto xinputDriver() const { return m_xinputDriver; }
+    auto xinputDriverSupported() const { return m_xinputDriver == QStringLiteral("libinput"); }
 
     int tappingEnabled() const;
     int naturalScrollingEnabled() const;

--- a/lxqt-config-input/touchpaddevice.h
+++ b/lxqt-config-input/touchpaddevice.h
@@ -49,6 +49,7 @@ public:
 
     const QString& name() const { return m_name; }
     QString escapedName() const;
+    QString xinputDriver() const { return m_xinputDriver; }
 
     int tappingEnabled() const;
     int naturalScrollingEnabled() const;
@@ -72,6 +73,7 @@ public:
     void saveSettings(LXQt::Settings* settings) const;
 private:
     QString m_name;
+    QString m_xinputDriver;
     QString devnode;
     int deviceid;
 


### PR DESCRIPTION
As the driver name cannot be queried directly from xinput api we use a "known" property instead.

Here's an example how it looks like:

![lxqt-config-input](https://user-images.githubusercontent.com/440517/93328445-01ba9800-f81c-11ea-985b-fd95c4d1e590.png)

The info is translatable and only visible, if `xinput driver != libinput`.

Closes #644 