### PR TITLE
Remember sizes of appearance and file associations dialogs

### DIFF
--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -126,8 +126,11 @@ int main (int argc, char **argv)
 
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowIcon(QIcon::fromTheme(QStringLiteral("preferences-desktop-theme")));
+    dialog->resize(mConfigAppearanceSettings.value(QStringLiteral("size")).toSize().expandedTo(QSize(600, 400)));
     dialog->show();
 
-    return app.exec();
+    int ret = app.exec();
+    mConfigAppearanceSettings.setValue(QStringLiteral("size"), dialog->size());
+    return ret;
 }
 

--- a/lxqt-config-file-associations/main.cpp
+++ b/lxqt-config-file-associations/main.cpp
@@ -57,9 +57,13 @@ int main (int argc, char **argv)
     MimetypeViewer mimetypeViewer;
     app.setActivationWindow(&mimetypeViewer);
     mimetypeViewer.setWindowIcon(QIcon::fromTheme(QStringLiteral("preferences-desktop-filetype-association")));
+    QSettings settings(QStringLiteral("lxqt"), QStringLiteral("lxqt-config-file-associations"));
+    mimetypeViewer.resize(settings.value(QStringLiteral("size")).toSize().expandedTo(QSize(600, 400)));
     mimetypeViewer.show();
 
-    return app.exec();
-    qDebug() << "Efter exec";
+    int ret = app.exec();
+    //qDebug() << "Efter exec";
+    settings.setValue(QStringLiteral("size"), mimetypeViewer.size());
+    return ret;
 }
 


### PR DESCRIPTION
Other dialogs should also remember their sizes but the above ones need it more.