### PR TITLE
Fixed regression in setting acceleration

### DIFF
--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -108,10 +108,10 @@ static bool xi2_set_device_property(int deviceid, const char* prop, QList<QVaria
 
     XFree(data);
 
-    auto dataType = values[0].type();
+    auto dataType = static_cast<QMetaType::Type>(values[0].type());
     switch (dataType)
     {
-    case QVariant::Int:
+    case QMetaType::Int:
         Q_ASSERT(act_type == XA_INTEGER);
 
         data = new unsigned char[values.size() * act_format / 8];
@@ -133,7 +133,7 @@ static bool xi2_set_device_property(int deviceid, const char* prop, QList<QVaria
             }
         }
         break;
-    case QVariant::Double:
+    case QMetaType::Float:
         Q_ASSERT(act_type == XInternAtom(dpy, "FLOAT", False));
         Q_ASSERT(act_format == 32);
         float_data = new float[values.size()];


### PR DESCRIPTION
The regression was introduced in https://github.com/lxqt/lxqt-config/pull/645, probably because `Float` wasn't a member of `QVariant`. (Dear contributors, please don't include unrelated changes into a single PR!)

The patch fixes the problem by using`QMetaType::Type`. As Qt doc says, the return value of `QVariant::type()` should be interpreted as `QMetaType::Type` (see https://doc.qt.io/qt-5/qvariant.html#type).

Fixes https://github.com/lxqt/lxqt-config/issues/676

@yan12125, we'll need a point release if you approve the PR.