### PR TITLE
load default color palette from theme

### DIFF
--- a/lxqt-config-appearance/styleconfig.h
+++ b/lxqt-config-appearance/styleconfig.h
@@ -50,6 +50,8 @@ public:
     ~StyleConfig();
 
     void applyStyle();
+    QPalette defaultPalette() const;
+    QPalette loadPalette(const QString& paletteFile) const;
 
 public slots:
     void initControls();


### PR DESCRIPTION
The "Default Palette" button now loads the color palette from the current theme (if it provides a `lxqt-palette.conf` file).
The previous default palette is used as a fallback.