### PR TITLE
lxqt-config-appearance works in Wayland server.

### DIFF
--- a/liblxqt-config-cursor/crtheme.cpp
+++ b/liblxqt-config-cursor/crtheme.cpp
@@ -225,28 +225,28 @@ bool haveXfixes()
     bool result = false;
     int event_base, error_base;
 
-
-    if(QGuiApplication::platformName() == QStringLiteral("xcb"))
-        if (XFixesQueryExtension(QX11Info::display(), &event_base, &error_base))
-        {
-            int major, minor;
-            XFixesQueryVersion(QX11Info::display(), &major, &minor);
-            result = (major >= 2);
-        }
+    if (XFixesQueryExtension(QX11Info::display(), &event_base, &error_base))
+    {
+        int major, minor;
+        XFixesQueryVersion(QX11Info::display(), &major, &minor);
+        result = (major >= 2);
+    }
     return result;
 }
 
 bool applyTheme(const XCursorThemeData &theme, int cursorSize)
 {
-    // Require the Xcursor version that shipped with X11R6.9 or greater, since
-    // in previous versions the Xfixes code wasn't enabled due to a bug in the
-    // build system (freedesktop bug #975).
-    if (!haveXfixes()) return false;
-    
-    // Sets default cursor size
-    if(QGuiApplication::platformName() == QStringLiteral("xcb"))
-        XcursorSetDefaultSize(QX11Info::display(), cursorSize);
+    bool isX11 = QGuiApplication::platformName() == QStringLiteral("xcb"); 
+    if(isX11)
+    {
+        // Require the Xcursor version that shipped with X11R6.9 or greater, since
+        // in previous versions the Xfixes code wasn't enabled due to a bug in the
+        // build system (freedesktop bug #975).
+        if (!haveXfixes()) return false;
 
+        // Sets default cursor size
+        XcursorSetDefaultSize(QX11Info::display(), cursorSize);
+    }
     // Set up the proper launch environment for newly started apps
     //k8:!!!:KToolInvocation::klauncher()->setLaunchEnv("XCURSOR_THEME", themeName);
 
@@ -275,8 +275,7 @@ bool applyTheme(const XCursorThemeData &theme, int cursorSize)
     for (const QString &name : qAsConst(names))
     {
         Cursor cursor = (Cursor)theme.loadCursorHandle(name);
-
-        if(QGuiApplication::platformName() == QStringLiteral("xcb"))
+        if(isX11)
             XFixesChangeCursorByName(QX11Info::display(), cursor, QFile::encodeName(name).constData());
         // FIXME: do we need to free the cursor?
     }

--- a/liblxqt-config-cursor/crtheme.h
+++ b/liblxqt-config-cursor/crtheme.h
@@ -31,8 +31,8 @@
 #include <QString>
 #include <QStringList>
 
-#include <xcb/xcb.h>
-#include <xcb/xproto.h>
+//#include <xcb/xcb.h>
+//#include <xcb/xproto.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // X11 is SHIT!

--- a/liblxqt-config-cursor/previewwidget.cpp
+++ b/liblxqt-config-cursor/previewwidget.cpp
@@ -32,6 +32,7 @@
 
 #include <QX11Info>
 #include <QWindow>
+#include <QGuiApplication>
 
 namespace {
     // Preview cursors
@@ -129,8 +130,10 @@ PreviewWidget::~PreviewWidget()
 void PreviewWidget::setCursorHandle(xcb_cursor_t cursorHandle)
 {
     WId wid = nativeParentWidget()->windowHandle()->winId();
-    xcb_change_window_attributes(QX11Info::connection(), wid, XCB_CW_CURSOR, &cursorHandle);
-    xcb_flush(QX11Info::connection());
+    if (QGuiApplication::platformName() == QStringLiteral("xcb")) {
+        xcb_change_window_attributes(QX11Info::connection(), wid, XCB_CW_CURSOR, &cursorHandle);
+        xcb_flush(QX11Info::connection());
+    }
 }
 
 

--- a/liblxqt-config-cursor/selectwnd.cpp
+++ b/liblxqt-config-cursor/selectwnd.cpp
@@ -39,6 +39,8 @@
 #include <QX11Info>
 #include <X11/Xcursor/Xcursor.h>
 
+#include <QGuiApplication>
+
 const QString HOME_ICON_DIR(QDir::homePath() + QStringLiteral("/.icons"));
 
 SelectWnd::SelectWnd(LXQt::Settings* settings, QWidget *parent)
@@ -48,7 +50,7 @@ SelectWnd::SelectWnd(LXQt::Settings* settings, QWidget *parent)
 {
     ui->setupUi(this);
     ui->warningLabel->hide();
-    ui->preview->setCurrentCursorSize(XcursorGetDefaultSize(QX11Info::display()));
+    ui->preview->setCurrentCursorSize(getDefaultCursorSize());
     ui->preview->setCursorSize(ui->preview->getCurrentCursorSize());
 
     mModel = new XCursorThemeModel(this);
@@ -69,7 +71,8 @@ SelectWnd::SelectWnd(LXQt::Settings* settings, QWidget *parent)
     connect(ui->warningLabel, &WarningLabel::showDirInfo, this, &SelectWnd::showDirInfo);
     
     // Set actual cursor size
-    ui->cursorSizeSpinBox->setValue(XcursorGetDefaultSize(QX11Info::display()));
+    ui->cursorSizeSpinBox->setValue(getDefaultCursorSize());
+
     
     connect(ui->cursorSizeSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &SelectWnd::cursorSizeChaged);
 

--- a/liblxqt-config-cursor/xcr/xcrimg.cpp
+++ b/liblxqt-config-cursor/xcr/xcrimg.cpp
@@ -17,10 +17,10 @@
 #include <QStyle>
 #include <QTextCodec>
 #include <QTextStream>
-
-#include <QProcess>
+#include <QSettings>
 #include <QX11Info>
 #include <QString>
+
 
 #include <X11/Xlib.h>
 #include <X11/Xcursor/Xcursor.h>
@@ -270,15 +270,13 @@ int getDefaultCursorSize()
         size = XcursorGetDefaultSize(QX11Info::display());
     else {
         // Wayland: get default cursor size
-        QProcess proc;
-        proc.start(QStringLiteral("gsettings"), QProcess::splitCommand(QStringLiteral("get org.gnome.desktop.interface cursor-size")), QIODevice::ReadOnly);
-        if(proc.waitForStarted()) {
-            proc.waitForFinished();
-            QByteArray buff = proc.readAll();
-            bool ok;
-            size = buff.toInt(&ok);
-            if(! ok) size = 24;
-        }
+        QString path = QDir::home().absolutePath() + QStringLiteral("/.icons/default/index.theme");
+        if(! QFile::exists(path))
+            path = QStringLiteral("/usr/share/icons/default/index.theme");
+        if(! QFile::exists(path))
+            return size;
+        QSettings cursorTheme(path, QSettings::IniFormat);
+        size = cursorTheme.value(QStringLiteral("Icon Theme/Size"), size).toInt();
     }
 
     return size;

--- a/liblxqt-config-cursor/xcr/xcrimg.h
+++ b/liblxqt-config-cursor/xcr/xcrimg.h
@@ -112,5 +112,6 @@ protected:
   QList<XCursorImage *> mList;
 };
 
+int getDefaultCursorSize();
 
 #endif

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -96,7 +96,7 @@ set org.gnome.desktop.interface cursor-size "%7"
  * GTK just doesn't intend to support image menu items. They're considered bad practice in modern UI. 
  */
 
-ConfigOtherToolKits::ConfigOtherToolKits(LXQt::Settings *settings,  LXQt::Settings *configAppearanceSettings, QWidget *parent) : QObject(parent)
+ConfigOtherToolKits::ConfigOtherToolKits(LXQt::Settings *settings,  LXQt::Settings *configAppearanceSettings, QObject *parent) : QObject(parent)
 {
     mSettings = settings;
     mConfigAppearanceSettings = configAppearanceSettings;
@@ -231,8 +231,10 @@ void ConfigOtherToolKits::setGsettingsConfig(QString version, QString theme)
             continue;
         QStringList args = QProcess::splitCommand(QStringView(command));
         bool ok = QProcess::startDetached(QStringLiteral("gsettings"), args);
-        if(!ok)
-            QMessageBox::critical((QWidget*) parent(), tr("Error"), tr("Error: gsettings can not be run"));
+        if(!ok) {
+            QMessageBox::critical((QWidget*) parent(), tr("Error"), tr("Error: gsettings cannot be run"));
+            break;
+        }
     }
 }
 

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -50,6 +50,7 @@ gtk-button-images = %4
 gtk-menu-images = %4
 gtk-toolbar-style = %5
 gtk-cursor-theme-name = %6
+gtk-cursor-theme-size = %7
 )GTK2_CONFIG";
 
 static const char *GTK3_CONFIG = R"GTK3_CONFIG(
@@ -63,6 +64,7 @@ gtk-menu-images = %4
 gtk-button-images = %4
 gtk-toolbar-style = %5
 gtk-cursor-theme-name = %6
+gtk-cursor-theme-size = %7
 )GTK3_CONFIG";
 
 static const char *XSETTINGS_CONFIG = R"XSETTINGS_CONFIG(
@@ -74,6 +76,7 @@ Gtk/FontName "%3"
 # Gtk/ButtonImages %4
 # Gtk/ToolbarStyle "%5"
 Gtk/CursorThemeName "%6"
+Gtk/CursorThemeSize %7
 )XSETTINGS_CONFIG";
 
 static const char *GTK3_GSETTINGS = R"GTK3_GSETTINGS(
@@ -82,7 +85,8 @@ set org.gnome.desktop.interface gtk-theme "%1"
 set org.gnome.desktop.interface font-name "%3"
 # set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ButtonImages': <%4>, 'Gtk/MenuImages': <%4>}"
 # set org.gnome.desktop.interface toolbar-style "%5"
-set org.gnome.desktop.interface cursor-theme "%6" 
+set org.gnome.desktop.interface cursor-theme "%6"
+set org.gnome.desktop.interface cursor-size "%7"
 )GTK3_GSETTINGS";
 
 /*
@@ -189,11 +193,8 @@ void ConfigOtherToolKits::setConfig()
     if(QGuiApplication::platformName() == QStringLiteral("xcb")) {
         // Call to xsettings to update config
         setXSettingsConfig();
-    } else if(QGuiApplication::platformName() == QStringLiteral("wayland")) {
-        setGsettingsConfig(QStringLiteral("3.0"));
-    } else {
-        qDebug() << "[lxqt-config-appearance]: Unknown platform";
     }
+    setGsettingsConfig(QStringLiteral("3.0"));
 }
 
 void ConfigOtherToolKits::setXSettingsConfig()
@@ -252,6 +253,7 @@ QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherTool
 {
     LXQt::Settings* sessionSettings = new LXQt::Settings(QStringLiteral("session"));
     QString mouseStyle = sessionSettings->value(QStringLiteral("Mouse/cursor_theme")).toString();
+    QString cursorSize = sessionSettings->value(QStringLiteral("Mouse/cursor_size")).toString();
     delete sessionSettings;
     switch(version) {
         case ConfigOtherToolKits::GTK3GSETTINGS:
@@ -267,7 +269,7 @@ QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherTool
                     toolBar = QStringLiteral("both-horiz");
                 return QString::fromUtf8(configString).arg(mConfig.styleTheme, mConfig.iconTheme,
                         mConfig.fontName, mConfig.buttonStyle==0 ? QStringLiteral("0"):QStringLiteral("1"),
-                        toolBar, mouseStyle
+                        toolBar, mouseStyle, cursorSize
                         );
             }
             break;
@@ -275,7 +277,7 @@ QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherTool
         case ConfigOtherToolKits::GTK2:
             return QString::fromUtf8(configString).arg(mConfig.styleTheme, mConfig.iconTheme,
             mConfig.fontName, mConfig.buttonStyle==0 ? QStringLiteral("0"):QStringLiteral("1"),
-            mConfig.toolButtonStyle, mouseStyle
+            mConfig.toolButtonStyle, mouseStyle, cursorSize
             );
     };
 

--- a/lxqt-config-appearance/configothertoolkits.h
+++ b/lxqt-config-appearance/configothertoolkits.h
@@ -36,7 +36,7 @@ class ConfigOtherToolKits : public QObject
     Q_OBJECT
 
 public:
-    ConfigOtherToolKits(LXQt::Settings *settings, LXQt::Settings *configAppearanceSettings, QWidget *parent = nullptr);
+    ConfigOtherToolKits(LXQt::Settings *settings, LXQt::Settings *configAppearanceSettings, QObject *parent = nullptr);
     ~ConfigOtherToolKits();
     QStringList getGTKThemes(QString version);
     QString getGTKThemeFromRCFile(QString version);

--- a/lxqt-config-appearance/configothertoolkits.h
+++ b/lxqt-config-appearance/configothertoolkits.h
@@ -36,7 +36,7 @@ class ConfigOtherToolKits : public QObject
     Q_OBJECT
 
 public:
-    ConfigOtherToolKits(LXQt::Settings *settings, LXQt::Settings *configAppearanceSettings, QObject *parent = nullptr);
+    ConfigOtherToolKits(LXQt::Settings *settings, LXQt::Settings *configAppearanceSettings, QWidget *parent = nullptr);
     ~ConfigOtherToolKits();
     QStringList getGTKThemes(QString version);
     QString getGTKThemeFromRCFile(QString version);
@@ -48,6 +48,7 @@ public slots:
     void setConfig();
     void setXSettingsConfig();
     void setGTKConfig(QString version, QString theme = QString());
+    void setGsettingsConfig(QString version, QString theme = QString());
 
 private:
     struct Config {
@@ -57,8 +58,12 @@ private:
         QString toolButtonStyle;
         int buttonStyle;
     } mConfig;
-    void writeConfig(QString path, const char *configString);
-    QString getConfig(const char *configString);
+
+    enum Version {
+        GTK2, GTK3, GTK3GSETTINGS
+    };
+    void writeConfig(QString path, const char *configString, Version version);
+    QString getConfig(const char *configString, Version version);
     void updateConfigFromSettings();
 
     LXQt::Settings *mSettings;

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -107,10 +107,8 @@ int main (int argc, char **argv)
     SelectWnd* cursorPage = new SelectWnd(sessionSettings, dialog);
     cursorPage->setCurrent();
     dialog->addPage(cursorPage, QObject::tr("Cursor"), QStringList() << QStringLiteral("input-mouse") << QStringLiteral("preferences-desktop"));
-    std::shared_ptr<bool> cursorChanged = std::make_shared<bool>(false);
-    QObject::connect(cursorPage, &SelectWnd::settingsChanged, dialog, [dialog, cursorChanged] {
+    QObject::connect(cursorPage, &SelectWnd::settingsChanged, dialog, [dialog] {
             dialog->enableButton(QDialogButtonBox::Apply, true);
-            *cursorChanged = true;
             });
 
     // apply all changes on clicking Apply
@@ -118,8 +116,6 @@ int main (int argc, char **argv)
         if (btn == QDialogButtonBox::Apply)
         {
             // FIXME: Update cursor style on Qt apps on wayland and GTK on X11. 
-            if(*cursorChanged)
-                QMessageBox::information(dialog, QDialog::tr("Information"), QDialog::tr("LXQT session needs restart after this changes.")); 
             iconPage->applyIconTheme();
             themePage->applyLxqtTheme();
             fontsPage->updateQtFont();
@@ -127,7 +123,6 @@ int main (int argc, char **argv)
             stylePage->applyStyle(); // Cursor and font have to be set before style
             // disable Apply button after changes are applied
             dialog->enableButton(btn, false);
-            *cursorChanged = false;
         }
         else if (btn == QDialogButtonBox::Reset)
             dialog->enableButton(QDialogButtonBox::Apply, false); // disable Apply button on resetting too

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -104,8 +104,7 @@ int main (int argc, char **argv)
 
     /*** Cursor Theme ***/
     SelectWnd* cursorPage = nullptr; 
-    LXQt::Platform::PLATFORM platform = LXQt::Platform::getPlatform();
-    if(platform == LXQt::Platform::X11) {
+    if(QGuiApplication::platformName() == QStringLiteral("xcb")) {
         cursorPage = new SelectWnd(sessionSettings, dialog);
         cursorPage->setCurrent();
         dialog->addPage(cursorPage, QObject::tr("Cursor"), QStringList() << QStringLiteral("input-mouse") << QStringLiteral("preferences-desktop"));

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -30,6 +30,8 @@
 #include <LXQt/Settings>
 #include <LXQt/ConfigDialog>
 #include <QCommandLineParser>
+#include <LXQt/lxqtplatform.h>
+
 #include "iconthemeconfig.h"
 #include "lxqtthemeconfig.h"
 #include "styleconfig.h"
@@ -101,12 +103,16 @@ int main (int argc, char **argv)
     });
 
     /*** Cursor Theme ***/
-    SelectWnd* cursorPage = new SelectWnd(sessionSettings, dialog);
-    cursorPage->setCurrent();
-    dialog->addPage(cursorPage, QObject::tr("Cursor"), QStringList() << QStringLiteral("input-mouse") << QStringLiteral("preferences-desktop"));
-    QObject::connect(cursorPage, &SelectWnd::settingsChanged, dialog, [dialog] {
-        dialog->enableButton(QDialogButtonBox::Apply, true);
-    });
+    SelectWnd* cursorPage = nullptr; 
+    LXQt::Platform::PLATFORM platform = LXQt::Platform::getPlatform();
+    if(platform == LXQt::Platform::X11) {
+        cursorPage = new SelectWnd(sessionSettings, dialog);
+        cursorPage->setCurrent();
+        dialog->addPage(cursorPage, QObject::tr("Cursor"), QStringList() << QStringLiteral("input-mouse") << QStringLiteral("preferences-desktop"));
+        QObject::connect(cursorPage, &SelectWnd::settingsChanged, dialog, [dialog] {
+                dialog->enableButton(QDialogButtonBox::Apply, true);
+                });
+    }
 
     // apply all changes on clicking Apply
     QObject::connect(dialog, &LXQt::ConfigDialog::clicked, [=] (QDialogButtonBox::StandardButton btn) {
@@ -115,7 +121,8 @@ int main (int argc, char **argv)
             iconPage->applyIconTheme();
             themePage->applyLxqtTheme();
             fontsPage->updateQtFont();
-            cursorPage->applyCusorTheme();
+            if(cursorPage != nullptr)
+                cursorPage->applyCusorTheme();
             stylePage->applyStyle(); // Cursor and font have to be set before style
             // disable Apply button after changes are applied
             dialog->enableButton(btn, false);

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -30,7 +30,6 @@
 #include <LXQt/Settings>
 #include <LXQt/ConfigDialog>
 #include <QCommandLineParser>
-#include <LXQt/lxqtplatform.h>
 #include <QMessageBox>
 #include <QGuiApplication>
 

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -36,7 +36,7 @@
 #include <QMetaProperty>
 #include <QMetaEnum>
 #include <QToolBar>
-#include <LXQt/lxqtplatform.h>
+#include <QGuiApplication>
 
 
 #ifdef Q_WS_X11
@@ -264,8 +264,7 @@ void StyleConfig::applyStyle()
         // GTK3
         themeName = ui->gtk3ComboBox->currentText();
         mConfigOtherToolKits->setGTKConfig(QStringLiteral("3.0"), themeName);
-        LXQt::Platform::PLATFORM platform = LXQt::Platform::getPlatform();
-        if(platform == LXQt::Platform::WAYLAND)
+        if(QGuiApplication::platformName() == QStringLiteral("wayland"))
             mConfigOtherToolKits->setGsettingsConfig(QStringLiteral("3.0"), themeName);
         // GTK2
         themeName = ui->gtk2ComboBox->currentText();

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -36,6 +36,8 @@
 #include <QMetaProperty>
 #include <QMetaEnum>
 #include <QToolBar>
+#include <LXQt/lxqtplatform.h>
+
 
 #ifdef Q_WS_X11
 extern void qt_x11_apply_settings_in_all_apps();
@@ -262,6 +264,9 @@ void StyleConfig::applyStyle()
         // GTK3
         themeName = ui->gtk3ComboBox->currentText();
         mConfigOtherToolKits->setGTKConfig(QStringLiteral("3.0"), themeName);
+        LXQt::Platform::PLATFORM platform = LXQt::Platform::getPlatform();
+        if(platform == LXQt::Platform::WAYLAND)
+            mConfigOtherToolKits->setGsettingsConfig(QStringLiteral("3.0"), themeName);
         // GTK2
         themeName = ui->gtk2ComboBox->currentText();
         mConfigOtherToolKits->setGTKConfig(QStringLiteral("2.0"), themeName);


### PR DESCRIPTION
Requires: [https://github.com/lxqt/liblxqt/pull/286](https://github.com/lxqt/liblxqt/pull/286)
Gtk 3 needs gsettings instead xsettings in Wayland server.