### PR TITLE
Make 'other settings' work in Configuration Center

### DIFF
--- a/src/lxqt-config.menu
+++ b/src/lxqt-config.menu
@@ -45,12 +45,12 @@
     <Menu>
         <Name>Other settings</Name>
         <Directory>lxqt-settings-other.directory</Directory>
-        <OnlyUnallocated />
         <Include>
             <And>
                 <Category>Settings</Category>
                 <Not>
                     <Or>
+                        <Filename>pcmanfm-qt-desktop-pref.desktop</Filename>
                         <Category>LXQt</Category>
                         <Category>LXDE</Category>
                         <Category>System</Category>
@@ -63,6 +63,7 @@
     <Layout>
         <Menuname>LXQt settings</Menuname>
         <Menuname>System settings</Menuname>
+        <Menuname>Other settings</Menuname>
         <Merge type="menus"/>
     </Layout>
 </Menu>

--- a/src/menuname/desktop-directories/lxqt-settings-other.directory.in
+++ b/src/menuname/desktop-directories/lxqt-settings-other.directory.in
@@ -1,0 +1,3 @@
+[Desktop Entry]
+Type=Directory
+

--- a/src/menuname/translations/lxqt-settings-other.directory.yaml
+++ b/src/menuname/translations/lxqt-settings-other.directory.yaml
@@ -1,0 +1,1 @@
+Desktop Entry/Name: "Other Settings"


### PR DESCRIPTION
It was half implemented, .directory and translation files missing. 
Will not show kdesystemsettings. 

![schermata-09-03-16-55](https://user-images.githubusercontent.com/10681413/132026817-514f7d9c-ca71-4b7c-9e38-a1d07196d4e5.png)

Closes https://github.com/lxqt/lxqt-config/issues/761
