### PR TITLE
Save and load Qt palettes

### DIFF
--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -34,6 +34,7 @@ set(UI_FILES
     iconthemeconfig.ui
     lxqtthemeconfig.ui
     fontsconfig.ui
+    palettes.ui
     styleconfig.ui
 )
 

--- a/lxqt-config-appearance/palettes.ui
+++ b/lxqt-config-appearance/palettes.ui
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PalettesDialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Palettes</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Palettes</string>
+     </property>
+     <property name="margin">
+      <number>5</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QListWidget" name="listWidget"/>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLineEdit" name="lineEdit">
+     <property name="placeholderText">
+      <string>Filter...</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QToolButton" name="removeButton">
+     <property name="text">
+      <string>&amp;Remove</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -294,6 +294,7 @@ void StyleConfig::savePalette()
     QString name = QInputDialog::getText(this, tr("Save Palette"), tr("Palette name:"), QLineEdit::Normal, QString(), &ok);
     if (!ok || name.isEmpty())
         return;
+    name = name.replace(QLatin1String("/"), QLatin1String(" ")).simplified();
     const QString paletteFile = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
                                 + QLatin1String("/lxqt/palettes/") + name;
     if (QFile::exists(paletteFile))

--- a/lxqt-config-appearance/styleconfig.h
+++ b/lxqt-config-appearance/styleconfig.h
@@ -59,6 +59,8 @@ signals:
 
 private slots:
     void showAdvancedOptions(bool on);
+    void savePalette();
+    void loadPalette();
 
 private:
     Ui::StyleConfig *ui;

--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -209,6 +209,20 @@
              <number>10</number>
             </property>
             <item>
+             <widget class="QToolButton" name="savePaletteBtn">
+              <property name="text">
+               <string>&amp;Save Palette</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="loadPaletteBtn">
+              <property name="text">
+               <string>&amp;Load Palette</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_2">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Palettes are saved into `$XDG_DATA_HOME/lxqt/palettes/` and loaded from `$XDG_DATA_DIRS/lxqt/palettes/` (root palettes can be installed in places like `/usr/share/lxqt/palettes/`). The patch only relies on Qt to handle these directories.

Palette files have no extension; they're distinguished by their parent folders and their names.

Malformed files or sections are silently ignored. Although they're listed, the active palette is used instead of them.

NOTE: In this PR, I also corrected an old mistake (typo) that, by chance, had no effect.

Closes https://github.com/lxqt/lxqt-config/issues/771