### PR TITLE
Remove Qt4 dead conditional code

### DIFF
--- a/lxqt-config-appearance/fontsconfig.cpp
+++ b/lxqt-config-appearance/fontsconfig.cpp
@@ -38,10 +38,6 @@
 #include <QStringBuilder>
 #include <QDomDocument>
 
-#ifdef Q_WS_X11
-extern void qt_x11_apply_settings_in_all_apps();
-#endif
-
 static const char* subpixelNames[] = {"none", "rgb", "bgr", "vrgb", "vbgr"};
 static const char* hintStyleNames[] = {"hintnone", "hintslight", "hintmedium", "hintfull"};
 
@@ -186,11 +182,6 @@ void FontsConfig::updateQtFont()
         mQtSettings->sync();
 
         emit updateOtherSettings();
-
-#ifdef Q_WS_X11
-        qt_x11_apply_settings_in_all_apps();
-#endif
-
         update();
     }
 }

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -43,11 +43,6 @@
 #include <QDir>
 #include <QGuiApplication>
 
-
-#ifdef Q_WS_X11
-extern void qt_x11_apply_settings_in_all_apps();
-#endif
-
 StyleConfig::StyleConfig(LXQt::Settings* settings, QSettings* qtSettings, LXQt::Settings *configAppearanceSettings, ConfigOtherToolKits *configOtherToolKits, QWidget* parent) :
     QWidget(parent),
     ui(new Ui::StyleConfig),

--- a/lxqt-config-input/keyboardconfig.cpp
+++ b/lxqt-config-input/keyboardconfig.cpp
@@ -31,10 +31,6 @@
 #include <X11/Xlib.h>
 #include <X11/XKBlib.h>
 
-#ifdef Q_WS_X11
-extern void qt_x11_apply_settings_in_all_apps();
-#endif
-
 KeyboardConfig::KeyboardConfig(LXQt::Settings* _settings, QSettings* _qtSettings, QWidget* parent):
   QWidget(parent),
   settings(_settings),
@@ -89,7 +85,6 @@ void KeyboardConfig::initControls() {
 void KeyboardConfig::applyConfig()
 {
   bool acceptSetting = false;
-  bool applyX11 = false;
 
   /* apply keyboard values */
   if(delay != ui.keyboardDelay->value() || interval != ui.keyboardInterval->value())
@@ -112,7 +107,7 @@ void KeyboardConfig::applyConfig()
   if(flashTime != ui.cursorFlashTime->value())
   {
     flashTime = ui.cursorFlashTime->value();
-    acceptSetting = applyX11 = true;
+    acceptSetting = true;
   }
 
   if(numlock != ui.keyboardNumLock->isChecked())
@@ -123,14 +118,6 @@ void KeyboardConfig::applyConfig()
 
   if(acceptSetting)
     accept();
-
-#ifdef Q_WS_X11
-  if(applyX11)
-  {
-    qtSettings->sync();
-    qt_x11_apply_settings_in_all_apps();
-  }
-#endif
 }
 
 void KeyboardConfig::loadSettings() {

--- a/lxqt-config-input/mouseconfig.cpp
+++ b/lxqt-config-input/mouseconfig.cpp
@@ -32,10 +32,6 @@
 #include <X11/Xlib.h>
 #include <X11/XKBlib.h>
 
-#ifdef Q_WS_X11
-extern void qt_x11_apply_settings_in_all_apps();
-#endif
-
 MouseConfig::MouseConfig(LXQt::Settings* _settings, QSettings* _qtSettings, QWidget* parent):
   QWidget(parent),
   settings(_settings),
@@ -125,7 +121,6 @@ void MouseConfig::setLeftHandedMouse() {
 void MouseConfig::applyConfig()
 {
   bool acceptSetting = false;
-  bool applyX11 = false;
 
   if(leftHanded != ui.mouseLeftHanded->isChecked())
   {
@@ -137,31 +132,23 @@ void MouseConfig::applyConfig()
   if(doubleClickInterval != ui.doubleClickInterval->value())
   {
     doubleClickInterval = ui.doubleClickInterval->value();
-    acceptSetting = applyX11 = true;
+    acceptSetting = true;
   }
 
   if(wheelScrollLines != ui.wheelScrollLines->value())
   {
     wheelScrollLines = ui.wheelScrollLines->value();
-    acceptSetting = applyX11 = true;
+    acceptSetting = true;
   }
 
   if(singleClick != ui.singleClick->isChecked())
   {
     singleClick = ui.singleClick->isChecked();
-    acceptSetting = applyX11 = true;
+    acceptSetting = true;
   }
 
   if(acceptSetting)
     accept();
-
-#ifdef Q_WS_X11
-  if(applyX11)
-  {
-    qtSettings->sync();
-    qt_x11_apply_settings_in_all_apps();
-  }
-#endif
 }
 
 void MouseConfig::loadSettings() {


### PR DESCRIPTION
Q_WS_X11 was removed in Qt5. This code is dead since we ported to Qt5.
