### PR TITLE
lxqt-config-brightness: Set minimum backlight

### DIFF
--- a/lxqt-config-brightness/brightnesssettings.h
+++ b/lxqt-config-brightness/brightnesssettings.h
@@ -25,13 +25,14 @@
 #include "ui_brightnesssettings.h"
 
 #include <LXQt/lxqtbacklight.h>
+#include <LXQt/Settings>
 
 class BrightnessSettings: public QDialog
 {
 Q_OBJECT
 
 public:
-    BrightnessSettings(QWidget *parent =nullptr);
+    BrightnessSettings(LXQt::Settings *settings, QWidget *parent =nullptr);
     ~BrightnessSettings();
 
     void revertValues();
@@ -55,7 +56,9 @@ private:
     LXQt::Backlight *mBacklight;
     int mLastBacklightValue;
     int mInitialBacklightValue;
-
+    int mInitialMinBacklightValue;
+    int mMinBacklightValue;
+    LXQt::Settings *mSettings;
 };
 
 

--- a/lxqt-config-brightness/brightnesssettings.ui
+++ b/lxqt-config-brightness/brightnesssettings.ui
@@ -121,7 +121,7 @@
           <item>
            <widget class="QGroupBox" name="groupBox_3">
             <property name="toolTip">
-             <string>The minimun value for backlight value can be really brightness. 
+             <string>The minimum value for backlight value can be really brightness. 
 It is possible set this minimum value.
 Warning: If a very low backlight is set, a black screen can be shown.</string>
             </property>

--- a/lxqt-config-brightness/brightnesssettings.ui
+++ b/lxqt-config-brightness/brightnesssettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>466</width>
-    <height>252</height>
+    <width>557</width>
+    <height>403</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,94 +19,181 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>10</number>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <item>
-      <widget class="QLabel" name="headIconLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>☀</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="headLabel">
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Backlight and brightness settings:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="backlightGroupBox">
-     <property name="title">
-      <string>Backlight</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QToolButton" name="backlightDownButton">
-        <property name="text">
-         <string>☼</string>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QSlider" name="backlightSlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="backlightUpButton">
-        <property name="text">
-         <string>☀</string>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Brightness</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="leftMargin">
-       <number>2</number>
-      </property>
-      <property name="rightMargin">
-       <number>2</number>
-      </property>
-      <item>
-       <layout class="QVBoxLayout" name="layout"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="confirmCB">
-     <property name="text">
-      <string>Require confirmation after settings change</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Backlight and brightness settings</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="backlightGroupBox">
+         <property name="title">
+          <string>Backlight</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QToolButton" name="backlightDownButton">
+            <property name="text">
+             <string>☼</string>
+            </property>
+            <property name="autoRaise">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSlider" name="backlightSlider">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="backlightUpButton">
+            <property name="text">
+             <string>☀</string>
+            </property>
+            <property name="autoRaise">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Brightness</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="leftMargin">
+           <number>2</number>
+          </property>
+          <property name="rightMargin">
+           <number>2</number>
+          </property>
+          <item>
+           <layout class="QVBoxLayout" name="layout"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="confirmCB">
+         <property name="text">
+          <string>Require confirmation after settings change</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Advanced settings</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Backlight</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="toolTip">
+             <string>The minimun value for backlight value can be really brightness. 
+It is possible set this minimum value.
+Warning: If a very low backlight is set, a black screen can be shown.</string>
+            </property>
+            <property name="title">
+             <string>Minimum backlight</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_6">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QToolButton" name="minBacklightDownButton">
+                 <property name="text">
+                  <string>☼</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSlider" name="minBacklightSlider">
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="minBacklightUpButton">
+                 <property name="text">
+                  <string>☀</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QPushButton" name="checkMinBacklightButton">
+               <property name="toolTip">
+                <string/>
+               </property>
+               <property name="statusTip">
+                <string/>
+               </property>
+               <property name="whatsThis">
+                <string/>
+               </property>
+               <property name="text">
+                <string>Check</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -115,45 +202,12 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>BrightnessSettings</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>BrightnessSettings</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/lxqt-config-brightness/main.cpp
+++ b/lxqt-config-brightness/main.cpp
@@ -22,6 +22,7 @@
 #include <QDebug>
 #include <QTimer>
 #include <LXQt/SingleApplication>
+#include <LXQt/Settings>
 #include <QCommandLineParser>
 #include <QMessageBox>
 #include "brightnesssettings.h"
@@ -159,8 +160,10 @@ int main(int argn, char* argv[])
         Q_UNREACHABLE();
     }
 
+    LXQt::Settings session_settings(QStringLiteral("session"));
+
     if (config.mode == UiMode::GUI) {
-        BrightnessSettings brightnessSettings;
+        BrightnessSettings brightnessSettings(&session_settings);
         brightnessSettings.setWindowIcon(QIcon(QLatin1String(ICON_DIR) + QStringLiteral("/brightnesssettings.svg")));
         brightnessSettings.show();
         return app.exec();
@@ -184,7 +187,7 @@ int main(int argn, char* argv[])
 
         const int currentBacklight = mBacklight->getBacklight();
         const int maxBacklight = mBacklight->getMaxBacklight();
-        int backlight = ( currentBacklight + sign*(maxBacklight/50 + 1) )*qAbs(sign) + brightnessValue*maxBacklight;
+        int backlight = ( currentBacklight + sign*(maxBacklight/10 + 1) )*qAbs(sign) + brightnessValue*maxBacklight;
 
         mBacklight->setBacklight(backlight);
 


### PR DESCRIPTION
In some hardware the 5% as minimum value of backlight can be too brightness. Advanced options has been added to select this minimum value:

![2022-05-16 19;25;17](https://user-images.githubusercontent.com/1163139/168649616-212fd33d-9453-43fc-9a38-a1ad58b65efa.png)

