### PR TITLE
Fix potential segfault when loading keyboard layout settings

### DIFF
--- a/lxqt-config-input/keyboardlayoutconfig.cpp
+++ b/lxqt-config-input/keyboardlayoutconfig.cpp
@@ -85,7 +85,8 @@ void KeyboardLayoutConfig::loadSettings() {
 
     const int size = layouts.size(), variantsSize = variants.size();
     for(int i = 0; i < size; ++i) {
-      currentLayouts_.append(QPair<QString, QString>(QString::fromUtf8(layouts.at(i)), variantsSize > 0 ? QString::fromUtf8(variants.at(i)) : QString()));
+      // Note: there can be fewer variants than layouts configured
+      currentLayouts_.append(QPair<QString, QString>(QString::fromUtf8(layouts.at(i)), i < variantsSize ? QString::fromUtf8(variants.at(i)) : QString()));
     }
 
     setxkbmap.close();


### PR DESCRIPTION
Previously, lxqt-config-input would crash when setxkbmap reported at least one but fewer variants than layouts. Adjust the existing size check to prevent that from happening.

You can reproduce the current behavior by setting some layouts like so:

```bash
setxkbmap de,us nodeadkeys
```

Starting lxqt-config-input will now result in a crash.
If however you set the layouts like this, it will start just fine (note the comma):


```bash
setxkbmap de,us nodeadkeys,
```

In both cases, you can verify that setxkbmap will report the variants as entered:

```bash
setxkbmap -query -verbose 5
```

While I am not sure how I personally ended up with this configuration, I assume I am not the last person to potentially run into this issue.

