### PR TITLE
lxqt-config-monitor: add more header file inclusion for libkscreen 5.26.90

### DIFF
--- a/lxqt-config-monitor/kscreenutils.cpp
+++ b/lxqt-config-monitor/kscreenutils.cpp
@@ -2,6 +2,7 @@
 #include "timeoutdialog.h"
 
 #include <KScreen/Output>
+#include <KScreen/Mode>
 #include <KScreen/Config>
 #include <KScreen/GetConfigOperation>
 #include <KScreen/SetConfigOperation>

--- a/lxqt-config-monitor/loadsettings.cpp
+++ b/lxqt-config-monitor/loadsettings.cpp
@@ -23,6 +23,7 @@
 #include "kscreenutils.h"
 #include <KScreen/Output>
 #include <KScreen/Config>
+#include <KScreen/Mode>
 #include <KScreen/GetConfigOperation>
 #include <KScreen/SetConfigOperation>
 #include <LXQt/Settings>

--- a/lxqt-config-monitor/monitorpicture.cpp
+++ b/lxqt-config-monitor/monitorpicture.cpp
@@ -24,6 +24,7 @@
 #include <QDebug>
 #include <QVector2D>
 #include <QRectF>
+#include <KScreen/Mode>
 #include <QScrollBar>
 
 #include "configure.h"

--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -28,6 +28,7 @@
 #include "kscreenutils.h"
 
 #include <KScreen/Output>
+#include <KScreen/Mode>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <LXQt/Settings>

--- a/lxqt-config-monitor/monitorwidget.cpp
+++ b/lxqt-config-monitor/monitorwidget.cpp
@@ -22,6 +22,7 @@
 #include <QComboBox>
 #include <QStringBuilder>
 #include <QDialogButtonBox>
+#include <KScreen/Mode>
 #include <KScreen/EDID>
 
 #include <algorithm>


### PR DESCRIPTION
With https://github.com/KDE/libkscreen/commit/94f330959b0eda775418aef7faee80ce69144e63 , `#include <KScreen/Output>` no longer includes "mode.h" implicitly. So in lxqt-config-monitor, files using `class KScreen::Mode` should include `#include <KScreen/Mode>` explicitly.

Related: #903 .