### PR TITLE
Put cursor settings in `"~/.Xresources"`

### DIFF
--- a/liblxqt-config-cursor/cfgfile.h
+++ b/liblxqt-config-cursor/cfgfile.h
@@ -14,7 +14,7 @@
 #include <QString>
 
 QMultiMap<QString, QString> loadCfgFile(const QString &fname, bool forceLoCase=false);
-void fixXDefaults(const QString &themeName, int cursorSize);
+void setXcursor(const QString &themeName, int cursorSize);
 const QString findDefaultTheme();
 
 #endif


### PR DESCRIPTION
`~/.Xdefaults` is the old place, altough it is also written to.

This patch fixes the problem of not being able to set the cursor (size) with `lxqt-config-appearance` when Xresources from `/etc` is read.

Credit goes to @humpity for finding the main cause.

Fixes https://github.com/lxqt/lxqt-config/issues/937