### PR TITLE
Update the windowTitle string in applicationchooser.ui

### DIFF
--- a/lxqt-config-file-associations/applicationchooser.ui
+++ b/lxqt-config-file-associations/applicationchooser.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>ApplicationChooser</string>
+   <string>Application Chooser</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
Change windowTitle string to include a space: "ApplicationChooser" → "Application Chooser".

Closes #860.