### PR TITLE
Don't return uninitialized struct member

### DIFF
--- a/lxqt-config-monitor/monitorpicture.cpp
+++ b/lxqt-config-monitor/monitorpicture.cpp
@@ -257,8 +257,8 @@ void MonitorPicture::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 //////////////////////////////////////////////////////////////////////////////////
 
 struct Result_moveMonitorPictureToNearest {
-    bool ok;
-    bool outside;
+    bool ok = false;
+    bool outside = false;
     QVector2D vector;
 };
 


### PR DESCRIPTION
At Result_moveMonitorPictureToNearest compareTwoMonitors() with:
    if(monitorPicture1Rect.intersects(monitorPicture2Rect)) {
        result.ok = true;
        return result;
    }
result.outside is returned without initialization.