### PR TITLE
Make Locale Config comboboxes not editable

### DIFF
--- a/lxqt-config-locale/combobox.h
+++ b/lxqt-config-locale/combobox.h
@@ -38,7 +38,6 @@ public:
         setInsertPolicy(QComboBox::NoInsert);
         completer()->setCompletionMode(QCompleter::PopupCompletion);
         completer()->setFilterMode(Qt::MatchContains);
-        lineEdit()->setClearButtonEnabled(true);
     }
 
 protected:

--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -129,6 +129,7 @@ void LocaleConfig::initCombo(QComboBox *combo, const QList<QLocale> & allLocales
     for(const QLocale & l : qAsConst(allLocales))
     {
         addLocaleToCombo(combo, l);
+        combo->setEditable(false);
     }
 }
 


### PR DESCRIPTION
Given that the comboboxes are formatted as: "\<Country\> - \<Language\> (\<LANG\>)", it's unlikely that someone would type their locale in manually. This simplifies the GUI; however, I have concerns in the case of when a locale is missing from the list somehow.