### PR TITLE
Locale config: Add 'Apply' button

### DIFF
--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -111,6 +111,7 @@ void LocaleConfig::load()
     connect(m_ui->checkDetailed, &QGroupBox::toggled, [ = ]()
     {
         updateExample();
+        emit enableApply(true);
         hasChanged = true;
     });
 
@@ -135,8 +136,9 @@ void LocaleConfig::connectCombo(QComboBox *combo)
 {
     connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged), [ = ]()
     {
-        hasChanged = true;
         updateExample();
+        emit enableApply(true);
+        hasChanged = true;
     });
 }
 
@@ -304,22 +306,27 @@ void LocaleConfig::writeConfig()
     mSettings->endGroup();
 }
 
+void LocaleConfig::clickedEventFilter(QDialogButtonBox::StandardButton btn)
+{
+    if (btn == QDialogButtonBox::Apply)
+    {
+        saveSettings();
+        emit enableApply(false);
+    }
+}
+
 void LocaleConfig::saveSettings()
 {
     if (hasChanged)
     {
         QMessageBox msgBox;
         msgBox.setWindowTitle(tr("Format Settings Changed"));
-        msgBox.setText(tr("Do you want to save your changes? They will take effect the next time you log in."));
-        msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Cancel);
-        msgBox.setDefaultButton(QMessageBox::Cancel);
+        msgBox.setText(tr("Settings will take effect the next time you log in."));
+        msgBox.setStandardButtons(QMessageBox::Ok);
 
-        int ret = msgBox.exec();
-        if( ret == QMessageBox::Save )
-        {
-            writeConfig();
-            writeExports();
-        }
+        msgBox.exec();
+        writeConfig();
+        writeExports();
     }
 
 }

--- a/lxqt-config-locale/localeconfig.h
+++ b/lxqt-config-locale/localeconfig.h
@@ -28,6 +28,7 @@
 #define LOCALECONFIG_H
 
 #include <QWidget>
+#include <QDialogButtonBox>
 #include <LXQt/Settings>
 
 class QTreeWidgetItem;
@@ -53,8 +54,12 @@ public:
     void save();
     void defaults();
 
+signals:
+    void enableApply(bool state);
+
 public slots:
     void initControls();
+    void clickedEventFilter(QDialogButtonBox::StandardButton btn);
     void saveSettings();
 
 private:

--- a/lxqt-config-locale/main.cpp
+++ b/lxqt-config-locale/main.cpp
@@ -53,8 +53,14 @@ int main (int argc, char **argv)
     LocaleConfig* localePage = new LocaleConfig(&settings, &session_settings, dialog);
     dialog->addPage(localePage, QObject::tr("Locale Settings"), QStringList() << QStringLiteral("preferences-desktop-locale") << QStringLiteral("preferences-desktop"));
     QObject::connect(dialog, &LXQt::ConfigDialog::reset, localePage, &LocaleConfig::initControls);
-    QObject::connect(dialog, &LXQt::ConfigDialog::save, localePage, &LocaleConfig::saveSettings);
 
+    QObject::connect(dialog, &LXQt::ConfigDialog::clicked, localePage, &LocaleConfig::clickedEventFilter);
+    QObject::connect(localePage, &LocaleConfig::enableApply, dialog, [dialog](bool state) {
+        dialog->enableButton(QDialogButtonBox::Apply, state);
+    });
+
+    dialog->setButtons(QDialogButtonBox::Reset | QDialogButtonBox::Apply | QDialogButtonBox::Close);
+    dialog->enableButton(QDialogButtonBox::Apply, false);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowIcon(QIcon::fromTheme(QStringLiteral("preferences-desktop-locale")));
     dialog->show();


### PR DESCRIPTION
Replaces the confirmation message box upon closing with an Apply button.

My prior attempt (#957) used `extern`; this instead uses signals/slots.