### PR TITLE
lxqt-config-input: Fixes a FTBFS with Clang

### DIFF
--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -368,7 +368,12 @@ bool TouchpadDevice::setTapToDragEnabled(bool enabled) const
 
 bool TouchpadDevice::setAccelSpeed(float speed) const
 {
-    return set_xi2_property(LIBINPUT_PROP_ACCEL, QList<QVariant>({speed}));
+    // Clang is very fussy with narrowing in initializer list
+    // We just avoid it.
+    QList<QVariant> l;
+    l.append(speed);
+
+    return set_xi2_property(LIBINPUT_PROP_ACCEL, l);
 }
 
 int TouchpadDevice::scrollMethodsAvailable() const


### PR DESCRIPTION
It fails to build with, at least, clang version 16.0.6.