### PR TITLE
Show unsupported message under wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Configures hardware of pointer devices. Settings like repeat delay and interval
 of keyboards or acceleration of pointer devices.
 
 Binary `lxqt-config-input`.
+**Note**: Not supported currently under wayland.
 
 #### Locale
 
@@ -58,6 +59,8 @@ Binary `lxqt-config-locale`.
 Adjusts screen resolutions, positioning of screens and the likes.
 
 Binary `lxqt-config-monitor`.
+
+**Note**: Not supported currently under wlroots based compositors.
 
 ### Configuration Center
 

--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -35,14 +35,6 @@
 int main(int argc, char** argv) {
     LXQt::SingleApplication app(argc, argv);
 
-    if (QGuiApplication::platformName() == QLatin1String("wayland"))
-    {
-        QMessageBox::warning(nullptr,
-            QObject::tr("Platform unsupported"),
-            QObject::tr("LXQt input settings are currently unsupported under wayland.\n\nMouse, touchpad and keyboard can be configured in the settings of the compositor."));
-        return 0;
-    }
-
     QCommandLineParser parser;
     LXQt::ConfigDialogCmdLineOptions dlgOptions;
     parser.setApplicationDescription(QStringLiteral("LXQt Config Input"));
@@ -74,6 +66,14 @@ int main(int argc, char** argv) {
         return 0;
     }
 #endif
+    // Show message under wayland only if no options are given
+    if (QGuiApplication::platformName() == QLatin1String("wayland"))
+    {
+        QMessageBox::warning(nullptr,
+            QObject::tr("Platform unsupported"),
+            QObject::tr("LXQt input settings are currently unsupported under wayland.\n\nMouse, touchpad and keyboard can be configured in the settings of the compositor."));
+        return 0;
+    }
 
     LXQt::ConfigDialog dlg(QObject::tr("Keyboard and Mouse Settings"), &settings);
     dlg.setButtons(QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::Reset);

--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -21,6 +21,7 @@
 #include <LXQt/ConfigDialogCmdLineOptions>
 #include <LXQt/Settings>
 #include <QCommandLineParser>
+#include <QMessageBox>
 #include "mouseconfig.h"
 #include "keyboardconfig.h"
 #include "../liblxqt-config-cursor/selectwnd.h"
@@ -33,6 +34,14 @@
 
 int main(int argc, char** argv) {
     LXQt::SingleApplication app(argc, argv);
+
+    if (QGuiApplication::platformName() == QLatin1String("wayland"))
+    {
+        QMessageBox::warning(nullptr,
+            QObject::tr("Platform unsupported"),
+            QObject::tr("LXQt input settings are currently unsupported under wayland.\n\nMouse, touchpad and keyboard can be configured in the settings of the compositor."));
+        return 0;
+    }
 
     QCommandLineParser parser;
     LXQt::ConfigDialogCmdLineOptions dlgOptions;


### PR DESCRIPTION
Maybe we could change this in futere to a dialog "Open compositor settings if available?"
* if kwin:
A list to open keyboard settings `kcmshell6 kcm_keyboard`  or just launch `systemsettings`

* if wayfire launch `wcm`
* if labwc launch `labwc-tweaks` (atm not complete)
