### PR TITLE
Do not load monitor or input settings under Wayland

### DIFF
--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -35,6 +35,8 @@
 int main(int argc, char** argv) {
     LXQt::SingleApplication app(argc, argv);
 
+    QString waylandMsg = QObject::tr("LXQt input settings are currently unsupported under wayland.\n\nMouse, touchpad and keyboard can be configured in the settings of the compositor.");
+
     QCommandLineParser parser;
     LXQt::ConfigDialogCmdLineOptions dlgOptions;
     parser.setApplicationDescription(QStringLiteral("LXQt Config Input"));
@@ -62,16 +64,17 @@ int main(int argc, char** argv) {
 #ifdef WITH_TOUCHPAD
     bool loadLastTouchpadSettings = parser.isSet(loadOption);
     if (loadLastTouchpadSettings) {
-        TouchpadDevice::loadSettings(&settings);
+        if (QGuiApplication::platformName() == QLatin1String("wayland"))
+            qDebug().noquote() << waylandMsg; // Under wayland, show a debug message and exit.
+        else
+            TouchpadDevice::loadSettings(&settings);
         return 0;
     }
 #endif
-    // Show message under wayland only if no options are given
+
     if (QGuiApplication::platformName() == QLatin1String("wayland"))
-    {
-        QMessageBox::warning(nullptr,
-            QObject::tr("Platform unsupported"),
-            QObject::tr("LXQt input settings are currently unsupported under wayland.\n\nMouse, touchpad and keyboard can be configured in the settings of the compositor."));
+    { // Show a message dialog under wayland if no options are given.
+        QMessageBox::warning(nullptr, QObject::tr("Platform unsupported"), waylandMsg);
         return 0;
     }
 

--- a/lxqt-config-monitor/loadsettings.cpp
+++ b/lxqt-config-monitor/loadsettings.cpp
@@ -102,7 +102,9 @@ void LoadSettings::applyBestSettings()
                 }
             }
             if(ok)
-                qDebug() << "lxqt-config-monitor: Settings applied.";
+                qDebug() << tr("lxqt-config-monitor: Settings applied.");
+            else
+                qDebug().noquote() << tr("lxqt-config-monitor: Settings not applied.\nIf this is a Wayland compositor, you could try kanshi to configure your monitor(s).");
             operation->deleteLater();
             QCoreApplication::instance()->exit(0);
         }

--- a/lxqt-config-monitor/main.cpp
+++ b/lxqt-config-monitor/main.cpp
@@ -27,27 +27,8 @@
 #include <QCoreApplication>
 #include "loadsettings.h"
 
-static bool loadSettingsOk(int argc, char** argv)
-{
-    for(int i=0; i<argc; i++) {
-        if(QString::fromUtf8(argv[i]) == QLatin1String("-l"))
-            return true;
-    }
-    return false;
-}
-
 int main(int argc, char** argv)
 {
-    if( loadSettingsOk(argc, argv) ) {
-        // If -l option is provided, settings are loaded and app is closed.
-        QGuiApplication app(argc, argv);
-        LoadSettings load;
-        load.applyBestSettings();
-        qDebug() << "[load.applyBestSettings()] Finished";
-        //QCoreApplication::instance()->exit(0);
-        return app.exec();
-    }
-
     LXQt::SingleApplication app(argc, argv);
 
     // Command line options
@@ -64,7 +45,13 @@ int main(int argc, char** argv)
     parser.addHelpOption();
 
     parser.process(app);
-    //bool loadLastSettings = parser.isSet(loadOption);
+
+    if (parser.isSet(loadOption))
+    { // If -l option is provided, settings are loaded and app is closed.
+        LoadSettings load;
+        load.applyBestSettings();
+        return app.exec();
+    }
 
     MonitorSettingsDialog dlg;
     app.setActivationWindow(&dlg);


### PR DESCRIPTION
Because, otherwise, crash will happen.

KWin is automatically excluded from this for monitor settings.