### PR TITLE
Write Fonts settings to LXQt config

### DIFF
--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -41,6 +41,8 @@
 #include <sys/types.h>
 #include <signal.h>
 
+#include "fontconfigfile.h"
+
 static const char *GTK2_CONFIG = R"GTK2_CONFIG(
 # Created by lxqt-config-appearance (DO NOT EDIT!)
 gtk-theme-name = "%1"
@@ -177,6 +179,8 @@ bool ConfigOtherToolKits::backupGTKSettings(QString version)
 
 void ConfigOtherToolKits::setConfig()
 {
+    setFontsConfig();
+
     if(!mConfigAppearanceSettings->contains(QStringLiteral("ControlGTKThemeEnabled")))
         mConfigAppearanceSettings->setValue(QStringLiteral("ControlGTKThemeEnabled"), false);
     bool controlGTKThemeEnabled = mConfigAppearanceSettings->value(QStringLiteral("ControlGTKThemeEnabled")).toBool();
@@ -249,6 +253,12 @@ void ConfigOtherToolKits::setGTKConfig(QString version, QString theme)
         writeConfig(gtkrcPath, GTK2_CONFIG, ConfigOtherToolKits::GTK2);
     else
         writeConfig(gtkrcPath, GTK3_CONFIG, ConfigOtherToolKits::GTK3);
+}
+
+void ConfigOtherToolKits::setFontsConfig()
+{
+    FontConfigFile fontConfigFile(mSettings);
+    fontConfigFile.save();
 }
 
 QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherToolKits::Version version)
@@ -441,4 +451,3 @@ void ConfigOtherToolKits::updateConfigFromSettings()
         }
     }
 }
-

--- a/lxqt-config-appearance/configothertoolkits.h
+++ b/lxqt-config-appearance/configothertoolkits.h
@@ -49,6 +49,7 @@ public slots:
     void setXSettingsConfig();
     void setGTKConfig(QString version, QString theme = QString());
     void setGsettingsConfig(QString version, QString theme = QString());
+    void setFontsConfig();
 
 private:
     struct Config {

--- a/lxqt-config-appearance/fontconfigfile.cpp
+++ b/lxqt-config-appearance/fontconfigfile.cpp
@@ -30,15 +30,12 @@
 #include <QDebug>
 #include <QStandardPaths>
 
-FontConfigFile::FontConfigFile(QObject* parent):
-    QObject(parent),
-    mAntialias(true),
-    mHinting(true),
-    mSubpixel("rgb"),
-    mHintStyle("hintslight"),
-    mDpi(96),
-    mAutohint(false),
-    mSaveTimer(nullptr)
+#include <LXQt/Settings>
+
+using namespace Qt::Literals::StringLiterals;
+
+FontConfigFile::FontConfigFile(LXQt::Settings *settings):
+    mSettings(settings)
 {
     mDirPath = QString::fromLocal8Bit(qgetenv("XDG_CONFIG_HOME"));
     QString homeDir = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
@@ -46,191 +43,64 @@ FontConfigFile::FontConfigFile(QObject* parent):
         mDirPath = homeDir + QStringLiteral("/.config");
     mDirPath += QLatin1String("/fontconfig");
     mFilePath = mDirPath + QStringLiteral("/fonts.conf");
-
-    load();
-}
-
-FontConfigFile::~FontConfigFile()
-{
-    if(mSaveTimer) // has pending save request
-    {
-        delete mSaveTimer;
-        mSaveTimer = nullptr;
-        save();
-    }
-}
-
-void FontConfigFile::setAntialias(bool value)
-{
-    mAntialias = value;
-    queueSave();
-}
-
-void FontConfigFile::setSubpixel(QByteArray value)
-{
-    mSubpixel = value;
-    queueSave();
-}
-
-void FontConfigFile::setHinting(bool value)
-{
-    mHinting = value;
-    queueSave();
-}
-
-void FontConfigFile::setHintStyle(QByteArray value)
-{
-    mHintStyle = value;
-    queueSave();
-}
-
-void FontConfigFile::setDpi(int value)
-{
-    mDpi = value;
-    queueSave();
-}
-
-void FontConfigFile::setAutohint(bool value)
-{
-    mAutohint = value;
-    queueSave();
-}
-
-void FontConfigFile::load()
-{
-    QFile file(mFilePath);
-    if(file.open(QIODevice::ReadOnly))
-    {
-        QByteArray buffer = file.readAll();
-        file.close();
-        if(buffer.contains("lxqt-config-appearance")) // the config file is created by us
-        {
-            // doing full xml parsing is over-kill. let's use some simpler brute-force methods.
-            QDomDocument doc;
-            doc.setContent(&file);
-            file.close();
-            QDomElement docElem = doc.documentElement();
-            QDomNodeList editNodes = docElem.elementsByTagName(QStringLiteral("edit"));
-            for(int i = 0; i < editNodes.count(); ++i)
-            {
-                QDomElement editElem = editNodes.at(i).toElement();
-                QByteArray name = editElem.attribute(QStringLiteral("name")).toLatin1();
-                if(name == "antialias")
-                {
-                    QString value = editElem.firstChildElement(QStringLiteral("bool")).text();
-                    mAntialias = value[0] == QLatin1Char('t') ? true : false;
-                }
-                else if(name == "rgba")
-                {
-                    QString value = editElem.firstChildElement(QStringLiteral("const")).text();
-                    mSubpixel = value.toLatin1();
-                }
-                else if(name == "hinting")
-                {
-                    QString value = editElem.firstChildElement(QStringLiteral("bool")).text();
-                    mHinting = value[0] == QLatin1Char('t') ? true : false;
-                }
-                else if(name == "hintstyle")
-                {
-                    QString value = editElem.firstChildElement(QStringLiteral("const")).text();
-                    mHintStyle = value.toLatin1();
-                }
-                else if(name == "dpi")
-                {
-                    QString value = editElem.firstChildElement(QStringLiteral("double")).text();
-                    mDpi = value.toInt();
-                }
-                else if(name == "autohint")
-                {
-                    QString value = editElem.firstChildElement(QStringLiteral("bool")).text();
-                    mAutohint = value[0] == QLatin1Char('t') ? true : false;
-                }
-            }
-        }
-        else // the config file is created by others => make a backup and write our config
-        {
-            QFile backup(mFilePath + QStringLiteral(".bak"));
-            if(backup.open(QIODevice::WriteOnly))
-            {
-                backup.write(buffer);
-                backup.close();
-            }
-            queueSave(); // overwrite with our file
-        }
-    }
 }
 
 void FontConfigFile::save()
 {
-    if(mSaveTimer)
-    {
-        mSaveTimer->deleteLater();
-        mSaveTimer = nullptr;
-    }
-
     QFile file(mFilePath);
     QDir().mkdir(mDirPath);
     // References: https://wiki.archlinux.org/index.php/Font_Configuration
-    if(file.open(QIODevice::WriteOnly))
-    {
-        QTextStream s(&file);
-        s <<
-        "<?xml version=\"1.0\"?>\n"
-        "<!DOCTYPE fontconfig SYSTEM \"fonts.dtd\">\n"
-        "<!-- created by lxqt-config-appearance (DO NOT EDIT!) -->\n"
-        "<fontconfig>\n"
-        "  <include ignore_missing=\"yes\">conf.d</include>\n"
-        "  <match target=\"font\">\n"
-        "    <edit name=\"antialias\" mode=\"assign\">\n"
-        "      <bool>" << (mAntialias ? "true" : "false") << "</bool>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "  <match target=\"font\">\n"
-        "    <edit name=\"rgba\" mode=\"assign\">\n"
-        "      <const>" << mSubpixel << "</const>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "  <match target=\"font\">\n"
-        "    <edit name=\"lcdfilter\" mode=\"assign\">\n"
-        "      <const>lcddefault</const>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "  <match target=\"font\">\n"
-        "    <edit name=\"hinting\" mode=\"assign\">\n"
-        "      <bool>" << (mHinting ? "true" : "false") << "</bool>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "  <match target=\"font\">\n"
-        "    <edit name=\"hintstyle\" mode=\"assign\">\n"
-        "      <const>" << mHintStyle << "</const>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "  <match target=\"font\">\n"
-        "    <edit name=\"autohint\" mode=\"assign\">\n"
-        "      <bool>" << (mAutohint ? "true" : "false") << "</bool>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "  <match target=\"pattern\">\n"
-        "    <edit name=\"dpi\" mode=\"assign\">\n"
-        "      <double>" << mDpi << "</double>\n"
-        "    </edit>\n"
-        "  </match>\n"
-        "</fontconfig>";
-        s.flush();
-        file.close();
-    }
-}
+    if(!file.open(QIODevice::WriteOnly))
+        return;
 
-void FontConfigFile::queueSave()
-{
-    if(mSaveTimer)
-        mSaveTimer->start(1500);
-    else
-    {
-        mSaveTimer = new QTimer();
-        mSaveTimer->setSingleShot(true);
-        connect(mSaveTimer, &QTimer::timeout, this, &FontConfigFile::save);
-        mSaveTimer->start(1500);
-    }
-}
+    bool antialias = mSettings->value("Fonts/Antialias"_L1, true).toBool();
+    QByteArray subpixel = mSettings->value("Fonts/Subpixel"_L1, "rgb"_ba).toByteArray();
+    bool hinting = mSettings->value("Fonts/Hinting"_L1, true).toBool();
+    QByteArray hintStyle = mSettings->value("Fonts/Hintstyle"_L1, "hintslight"_ba).toByteArray();
+    bool autohint = mSettings->value("Fonts/Autohint"_L1, false).toBool();
+    int dpi = mSettings->value("Fonts/DPI"_L1, 96).toInt();
 
+    QTextStream s(&file);
+    s <<
+    "<?xml version=\"1.0\"?>\n"
+    "<!DOCTYPE fontconfig SYSTEM \"fonts.dtd\">\n"
+    "<!-- created by lxqt-config-appearance (DO NOT EDIT!) -->\n"
+    "<fontconfig>\n"
+    "  <include ignore_missing=\"yes\">conf.d</include>\n"
+    "  <match target=\"font\">\n"
+    "    <edit name=\"antialias\" mode=\"assign\">\n"
+    "      <bool>" << (antialias ? "true" : "false") << "</bool>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "  <match target=\"font\">\n"
+    "    <edit name=\"rgba\" mode=\"assign\">\n"
+    "      <const>" << subpixel << "</const>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "  <match target=\"font\">\n"
+    "    <edit name=\"lcdfilter\" mode=\"assign\">\n"
+    "      <const>lcddefault</const>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "  <match target=\"font\">\n"
+    "    <edit name=\"hinting\" mode=\"assign\">\n"
+    "      <bool>" << (hinting ? "true" : "false") << "</bool>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "  <match target=\"font\">\n"
+    "    <edit name=\"hintstyle\" mode=\"assign\">\n"
+    "      <const>" << hintStyle << "</const>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "  <match target=\"font\">\n"
+    "    <edit name=\"autohint\" mode=\"assign\">\n"
+    "      <bool>" << (autohint ? "true" : "false") << "</bool>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "  <match target=\"pattern\">\n"
+    "    <edit name=\"dpi\" mode=\"assign\">\n"
+    "      <double>" << dpi << "</double>\n"
+    "    </edit>\n"
+    "  </match>\n"
+    "</fontconfig>";
+}

--- a/lxqt-config-appearance/fontconfigfile.h
+++ b/lxqt-config-appearance/fontconfigfile.h
@@ -22,66 +22,23 @@
 #define FONTCONFIGFILE_H
 
 #include <QString>
-#include <QByteArray>
-#include <QObject>
 
-class QTimer;
-
-class FontConfigFile: public QObject
+namespace LXQt
 {
-    Q_OBJECT
+    class Settings;
+}
+
+class FontConfigFile
+{
 public:
-    explicit FontConfigFile(QObject* parent = nullptr);
-    virtual ~FontConfigFile();
+    explicit FontConfigFile(LXQt::Settings *settings);
 
-    bool antialias() const {
-        return mAntialias;
-    }
-    void setAntialias(bool value);
-
-    bool hinting() const {
-        return mHinting;
-    }
-    void setHinting(bool value);
-
-    QByteArray subpixel() const {
-        return mSubpixel;
-    }
-    void setSubpixel(QByteArray value);
-
-    QByteArray hintStyle() const {
-        return mHintStyle;
-    }
-    void setHintStyle(QByteArray value);
-
-    int dpi() const {
-        return mDpi;
-    }
-    void setDpi(int value);
-
-    bool autohint() const {
-        return mAutohint;
-    }
-    void setAutohint(bool value);
-
-
-private Q_SLOTS:
     void save();
 
 private:
-    void load();
-    void queueSave();
-
-private:
-    bool mAntialias;
-    bool mHinting;
-    QByteArray mSubpixel;
-    QByteArray mHintStyle;
-    int mDpi;
-    bool mAutohint;
     QString mDirPath;
     QString mFilePath;
-    QTimer* mSaveTimer;
+    LXQt::Settings *mSettings;
 };
 
 #endif // FONTCONFIGFILE_H

--- a/lxqt-config-appearance/fontsconfig.h
+++ b/lxqt-config-appearance/fontsconfig.h
@@ -31,7 +31,6 @@
 #include <QWidget>
 #include <QFont>
 #include <LXQt/Settings>
-#include "fontconfigfile.h"
 
 class QTreeWidgetItem;
 class QSettings;
@@ -61,7 +60,6 @@ private:
     Ui::FontsConfig *ui;
     QSettings *mQtSettings;
     LXQt::Settings *mSettings;
-    FontConfigFile mFontConfigFile;
 };
 
 #endif // FONTSCONFIG_H


### PR DESCRIPTION
Partially implements #1022

With this, functionality is not lost or changed.
The fontsconfig is still written, however all related values are now saved/loaded to `lxqt.conf` first.

There's one caveat because I don't your policy on this. If this gets merged as-is the user's old settings will be lost. The user will need to customize them again.
Do you want a migration code that will load the customized settings into the lxqt.conf from fonts.conf if they are missing? It will makes things much more complicated though...

If this gets approve the future PRs will be in these stages:
* stage 2: Write the Fonts settings into the appropriate values of xsettings/gsettings/settings.ini
* stage 3: Yank out the code for xsettings and migrate it to lxqt-session. Make the xsettings deamon start at session start and continue running for the whole session. Reload it when changes are done to the settings.
* stage 4: Investigate what needs to be done on the lxqt-qtplugin side.