### PR TITLE
Added checkbox to use palette provided by LXQt theme

### DIFF
--- a/lxqt-config-appearance/lxqtthemeconfig.h
+++ b/lxqt-config-appearance/lxqtthemeconfig.h
@@ -30,6 +30,7 @@
 
 #include <QWidget>
 #include <LXQt/Settings>
+#include "styleconfig.h"
 
 class QTreeWidgetItem;
 
@@ -42,7 +43,7 @@ class LXQtThemeConfig : public QWidget
     Q_OBJECT
 
 public:
-    explicit LXQtThemeConfig(LXQt::Settings *settings, QWidget *parent = nullptr);
+    explicit LXQtThemeConfig(LXQt::Settings *settings, StyleConfig *stylePage, QWidget *parent = nullptr);
     ~LXQtThemeConfig();
 
     void applyLxqtTheme();
@@ -56,10 +57,15 @@ signals:
 private slots:
     void doubleClicked(QTreeWidgetItem *item, int column);
     void contextMenu(const QPoint& p);
+    void onPaletteOverrideChanged(bool checked);
+    void onCurrentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*);
 
 private:
+    void loadThemePalette();
+
     Ui::LXQtThemeConfig *ui;
     LXQt::Settings *mSettings;
+    StyleConfig *mStylePage;
 };
 
 #endif // LXQTTHEMECONFIG_H

--- a/lxqt-config-appearance/lxqtthemeconfig.ui
+++ b/lxqt-config-appearance/lxqtthemeconfig.ui
@@ -58,6 +58,13 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QCheckBox" name="paletteOverride">
+     <property name="text">
+      <string>Use palette provided by theme</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -88,7 +88,7 @@ int main (int argc, char **argv)
     QObject::connect(iconPage, &IconThemeConfig::updateOtherSettings, configOtherToolKits, &ConfigOtherToolKits::setConfig);
 
     /*** LXQt Theme ***/
-    LXQtThemeConfig* themePage = new LXQtThemeConfig(settings, dialog);
+    LXQtThemeConfig* themePage = new LXQtThemeConfig(settings, stylePage, dialog);
     dialog->addPage(themePage, QObject::tr("LXQt Theme"), QStringList() << QStringLiteral("preferences-desktop-color") << QStringLiteral("preferences-desktop"));
     QObject::connect(dialog, &LXQt::ConfigDialog::reset, themePage, &LXQtThemeConfig::initControls);
     QObject::connect(themePage, &LXQtThemeConfig::settingsChanged, dialog, [dialog] {

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -426,65 +426,70 @@ void StyleConfig::loadPalette()
     dialog.setQuestion(tr("Do you really want to remove selected palette(s)?\nRoot palettes will remain intact if existing."));
 
     if (dialog.exec() == QDialog::Accepted)
-    { // set color labels
-        auto paletteFile = dialog.currentPalette();
-        if (paletteFile.isEmpty())
-            return;
-        QSettings settings(paletteFile, QSettings::IniFormat);
-        settings.beginGroup(QStringLiteral("Palette"));
-
-        QColor color;
-        color = QColor::fromString(settings.value(QStringLiteral("window_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::Window);
-        ui->winColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("base_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::Base);
-        ui->baseColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("highlight_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::Highlight);
-        ui->highlightColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("window_text_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::WindowText);
-        ui->windowTextColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("text_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::Text);
-        ui->viewTextColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("highlighted_text_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::HighlightedText);
-        ui->highlightedTextColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("link_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::Link);
-        ui->linkColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("link_visited_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Active,QPalette::LinkVisited);
-        ui->linkVisitedColorLabel->setColor(color, true);
-
-        // tooltips use the Inactive color group
-        color = QColor::fromString(settings.value(QStringLiteral("tooltip_base_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Inactive,QPalette::ToolTipBase);
-        ui->tooltipColorLabel->setColor(color, true);
-
-        color = QColor::fromString(settings.value(QStringLiteral("tooltip_text_color")).toString());
-        if (!color.isValid())
-            color = QGuiApplication::palette().color(QPalette::Inactive,QPalette::ToolTipText);
-        ui->tooltipTextColorLabel->setColor(color, true);
-
-        settings.endGroup();
+    {
+        loadPaletteFile(dialog.currentPalette());
     }
+}
+
+void StyleConfig::loadPaletteFile(const QString& paletteFile)
+{ // set color labels
+    if (paletteFile.isEmpty())
+        return;
+
+    QSettings settings(paletteFile, QSettings::IniFormat);
+    settings.beginGroup(QStringLiteral("Palette"));
+
+    QColor color;
+    color = QColor::fromString(settings.value(QStringLiteral("window_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::Window);
+    ui->winColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("base_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::Base);
+    ui->baseColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("highlight_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::Highlight);
+    ui->highlightColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("window_text_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::WindowText);
+    ui->windowTextColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("text_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::Text);
+    ui->viewTextColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("highlighted_text_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::HighlightedText);
+    ui->highlightedTextColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("link_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::Link);
+    ui->linkColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("link_visited_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Active,QPalette::LinkVisited);
+    ui->linkVisitedColorLabel->setColor(color, true);
+
+    // tooltips use the Inactive color group
+    color = QColor::fromString(settings.value(QStringLiteral("tooltip_base_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Inactive,QPalette::ToolTipBase);
+    ui->tooltipColorLabel->setColor(color, true);
+
+    color = QColor::fromString(settings.value(QStringLiteral("tooltip_text_color")).toString());
+    if (!color.isValid())
+        color = QGuiApplication::palette().color(QPalette::Inactive,QPalette::ToolTipText);
+    ui->tooltipTextColorLabel->setColor(color, true);
+
+    settings.endGroup();
 }

--- a/lxqt-config-appearance/styleconfig.h
+++ b/lxqt-config-appearance/styleconfig.h
@@ -47,6 +47,7 @@ public:
     ~StyleConfig();
 
     void applyStyle();
+    void loadPaletteFile(const QString& paletteFile);
 
 public slots:
     void initControls();

--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -127,28 +127,28 @@
                <widget class="ColorLabel" name="highlightColorLabel"/>
               </item>
               <item row="3" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>Link:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="ColorLabel" name="linkColorLabel"/>
-              </item>
-              <item row="4" column="0">
                <widget class="QLabel" name="label_3">
                 <property name="text">
                  <string>Tooltip:</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="1">
+              <item row="3" column="1">
                <widget class="ColorLabel" name="tooltipColorLabel">
                 <property name="text">
                  <string/>
                 </property>
                </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>Link:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="ColorLabel" name="linkColorLabel"/>
               </item>
              </layout>
             </item>
@@ -191,28 +191,28 @@
                <widget class="ColorLabel" name="highlightedTextColorLabel"/>
               </item>
               <item row="3" column="0">
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>Visited Link:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="ColorLabel" name="linkVisitedColorLabel"/>
-              </item>
-              <item row="4" column="0">
                <widget class="QLabel" name="label_4">
                 <property name="text">
                  <string>Tooltip Text:</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="1">
+              <item row="3" column="1">
                <widget class="ColorLabel" name="tooltipTextColorLabel">
                 <property name="text">
                  <string/>
                 </property>
                </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>Visited Link:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="ColorLabel" name="linkVisitedColorLabel"/>
               </item>
              </layout>
             </item>


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-config/issues/974

Also,
 * Save and restore the checked state of the checkbox for wallpaper overriding;
 * Swapped the rows of tooltip and link colors in the Qt Palette GUI.