### PR TITLE
Make sure Monitor Settings dialog is shown completely on Wayland

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -87,6 +87,9 @@ MonitorSettingsDialog::MonitorSettingsDialog() :
     });
 
     connect(ui.settingsButton, &QToolButton::clicked, this, &MonitorSettingsDialog::showSettingsDialog);
+
+    // make sure that widgets are shown completely (a Qt bug under Wayland?)
+    resize(sizeHint().expandedTo(QSize(600, 400)));
 }
 
 MonitorSettingsDialog::~MonitorSettingsDialog()


### PR DESCRIPTION
This is rather a simple workaround for undersized dialogs on Wayland (a new Qt bug), but it's good on X11 too.