### PR TITLE
Fixed the size of monitor dialog

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -150,7 +150,6 @@ void MonitorSettingsDialog::loadConfiguration(KScreen::ConfigPtr config)
         monitorPicture->setScene(monitors);
 
     ui.monitorList->setCurrentRow(0);
-    adjustSize();
 }
 
 void MonitorSettingsDialog::applyConfiguration(bool saveConfigOk)


### PR DESCRIPTION
As a side note, every change should be checked under both X11 and Wayland, *even if it seems elementary*. In this case `QWidget::adjustSize()` didn't have effect under Wayland, and that made me think that the dialog should be resized correctly under X11 too, while it wasn't.