### PR TITLE
lxqt-config-monitor: Change dialog button from QToolButton to QPushButton

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -86,7 +86,7 @@ MonitorSettingsDialog::MonitorSettingsDialog() :
 
     });
 
-    connect(ui.settingsButton, &QToolButton::clicked, this, &MonitorSettingsDialog::showSettingsDialog);
+    connect(ui.settingsButton, &QPushButton::clicked, this, &MonitorSettingsDialog::showSettingsDialog);
 
     // also make sure that widgets are shown completely (a Qt bug under Wayland?)
     LXQt::Settings settings(QStringLiteral("lxqt-config-monitor"));

--- a/lxqt-config-monitor/monitorsettingsdialog.ui
+++ b/lxqt-config-monitor/monitorsettingsdialog.ui
@@ -65,19 +65,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QToolButton" name="settingsButton">
+      <widget class="QPushButton" name="settingsButton">
        <property name="text">
         <string>Settings</string>
        </property>
        <property name="icon">
         <iconset theme="preferences-system">
          <normaloff>.</normaloff>.</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Change the "Settings" dialog button to a QPushButton. This simplifies the Designer UI file and fixes text/icon alignment (for example on Fusion.)