### PR TITLE
Scale monitor images on resizing monitor settings dialog

### DIFF
--- a/lxqt-config-monitor/monitorpicture.h
+++ b/lxqt-config-monitor/monitorpicture.h
@@ -44,8 +44,11 @@ public:
 
 protected:
     void showEvent(QShowEvent * event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
+    void updateScale(qreal scale);
+
     Ui::MonitorPictureDialog ui;
     QList<MonitorPicture*> pictures;
     bool updatingOk;
@@ -70,7 +73,7 @@ public:
 
 private:
     QGraphicsTextItem *textItem;
-    QGraphicsSvgItem *svgItem;    
+    QGraphicsSvgItem *svgItem;
     MonitorPictureDialog *monitorPictureDialog;
 
 
@@ -85,11 +88,11 @@ class MonitorPictureProxy: public QObject
     public:
         MonitorPictureProxy(QObject *parent, MonitorPicture *monitorPicture);
         MonitorPicture *monitorPicture;
-        
+
     public slots:
         void updateSize();
         void updatePosition();
-        
+
 };
 
 


### PR DESCRIPTION
Also, the images are made a little larger by default.

Closes https://github.com/lxqt/lxqt-config/issues/1053