### PR TITLE
Fixed the "Set Position" page in lxqt-config-monitor

### DIFF
--- a/lxqt-config-monitor/monitorpicture.cpp
+++ b/lxqt-config-monitor/monitorpicture.cpp
@@ -65,7 +65,7 @@ void MonitorPictureProxy::updatePosition()
 }
 
 MonitorPictureDialog::MonitorPictureDialog(KScreen::ConfigPtr config, QWidget * parent, Qt::WindowFlags f) :
-    QDialog(parent,f)
+    QWidget(parent,f)
 {
     updatingOk = false;
     firstShownOk = false;
@@ -79,7 +79,7 @@ void MonitorPictureDialog::setScene(QList<MonitorWidget *> monitors)
 {
     int monitorsWidth =0;
     int monitorsHeight = 0;
-    QGraphicsScene *scene = new QGraphicsScene();
+    QGraphicsScene *scene = new QGraphicsScene(this);
     for (MonitorWidget *monitor : monitors) {
         MonitorPicture *monitorPicture = new MonitorPicture(nullptr, monitor, this);
         pictures.append(monitorPicture);
@@ -109,7 +109,7 @@ void MonitorPictureDialog::showEvent(QShowEvent * event)
 
 void MonitorPictureDialog::resizeEvent(QResizeEvent *event)
 {
-    QDialog::resizeEvent(event);
+    QWidget::resizeEvent(event);
     if (firstShownOk && maxMonitorSize > 0)
     {
         qreal scale = ui.graphicsView->transform().m11();

--- a/lxqt-config-monitor/monitorpicture.h
+++ b/lxqt-config-monitor/monitorpicture.h
@@ -24,14 +24,13 @@
 #include <QGraphicsTextItem>
 #include <QSvgRenderer>
 #include <QGraphicsSvgItem>
-#include <QDialog>
 #include "monitor.h"
 #include "ui_monitorpicture.h"
 #include "monitorwidget.h"
 
 class MonitorPicture;
 
-class MonitorPictureDialog : public QDialog
+class MonitorPictureDialog : public QWidget
 {
     Q_OBJECT
 

--- a/lxqt-config-monitor/monitorpicture.ui
+++ b/lxqt-config-monitor/monitorpicture.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MonitorPictureDialog</class>
- <widget class="QDialog" name="MonitorPictureDialog">
+ <widget class="QWidget" name="MonitorPictureDialog">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
The latest version of Qt 6.8 showed a problem in the code: the "Set Position" page was visible behind the "Fast Menu" page on startup, although everything worked fine.

The reason was that `MonitorPictureDialog` was a `QDialog` that was added to a stacked widget. The problem was solved by changing it to a `QWidget`. However, I didn't change its name to `MonitorPictureWidget`, because I didn't want to make a messy patch.

Also, a memory leak is fixed inside the same class.

P.S.
The main issue was found by @stefonarch.