### PR TITLE
Use `iso-flags-svg` for flags in Locale Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ belonging to LXQt, too.
 
 Binary `lxqt-config-locale`.
 
+**Note**: The SVG ISO flags from `$XDG_DATA_DIRS/iso-flags-svg/country-4x3/` will be shown if `iso-flags-svg` is installed (whether as root or inside `~/.local/share/`).
+
 #### Monitor Settings
 
 Adjusts screen resolutions, positioning of screens and the likes.

--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -159,7 +159,7 @@ void LocaleConfig::addLocaleToCombo(QComboBox *combo, const QLocale &locale)
         flagcode = split[1].toLower();
     }
     /* TODO Find a better place for flags ... */
-    QString flag(QStandardPaths::locate(QStandardPaths::GenericDataLocation, QStringLiteral("kf5/locale/countries/%1/flag.png").arg(flagcode)));
+    QString flag(QStandardPaths::locate(QStandardPaths::GenericDataLocation, QStringLiteral("iso-flags-svg/country-4x3/%1.svg").arg(flagcode)));
     QIcon flagIcon;
     if (!flag.isEmpty())
     {


### PR DESCRIPTION
KDE removed all flag images from KF6 and started to use `KCountryFlagEmojiIconEngine`, belonging to `KGuiAddons`, which doesn't seem acceptable as a dependency for LXQt. Instead, this simple patch uses `iso-flags-svg` and searches inside `$XDG_DATA_DIRS/iso-flags-svg/country-4x3/` for SVG flag images, if existing.

NOTE: IMHO, making it configurable would be an overkill, because flags aren't necessary.