### PR TITLE
Cleanup man pages

### DIFF
--- a/liblxqt-config-cursor/CMakeLists.txt
+++ b/liblxqt-config-cursor/CMakeLists.txt
@@ -87,7 +87,7 @@ install(FILES
 )
 
 install(FILES
-    man/lxqt-config-mouse.1
+    man/lxqt-config-input.1
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
     COMPONENT Runtime
 )

--- a/liblxqt-config-cursor/man/lxqt-config-input.1
+++ b/liblxqt-config-cursor/man/lxqt-config-input.1
@@ -6,7 +6,7 @@ Environment
 .B lxqt-config-input
 .br
 .SH DESCRIPTION
-This is a simple GUI keyboard, mouse, and touchpad settings application for the
+This is a simple keyboard, mouse, and touchpad settings GUI application for the
 LXQt desktop environment.
 .P
 \fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt

--- a/liblxqt-config-cursor/man/lxqt-config-input.1
+++ b/liblxqt-config-cursor/man/lxqt-config-input.1
@@ -9,6 +9,16 @@ Environment
 This is a simple GUI application for keyboard, mouse, and touchpad settings.
 (Currently it can only run under X11.)
 .P
+.SH OPTIONS
+-s, --show-page <name>  Choose the page to be shown.
+.br
+--load-touchpad         Load last touchpad settings.
+.br
+-v, --version           Displays version information.
+.br
+-h, --help              Displays help on command line options.
+.br
+--help-all              Displays help, including generic Qt options
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxqt/lxqt-config/issues
 .SH "SEE ALSO"

--- a/liblxqt-config-cursor/man/lxqt-config-input.1
+++ b/liblxqt-config-cursor/man/lxqt-config-input.1
@@ -1,4 +1,4 @@
-.TH lxqt-config-input "1" "January 2025" "LXQt 2.1.0" "LXQt Input Settings"
+.TH LXQT-CONFIG-INPUT "1" "January 2025" "LXQt 2.1.0" "LXQt Input Settings"
 .SH NAME
 lxqt-config-input \- Application of \fBLXQt\fR: The Lightweight Qt Desktop
 Environment

--- a/liblxqt-config-cursor/man/lxqt-config-input.1
+++ b/liblxqt-config-cursor/man/lxqt-config-input.1
@@ -1,40 +1,19 @@
 .TH lxqt-config-input "1" "January 2025" "LXQt 2.1.0" "LXQt Input Settings"
 .SH NAME
-lxqt-config-input \- Application of \fBLXQt\fR: the faster and lighter Qt Desktop
+lxqt-config-input \- Application of \fBLXQt\fR: The Lightweight Qt Desktop
 Environment
 .SH SYNOPSIS
 .B lxqt-config-input
 .br
 .SH DESCRIPTION
-This is a simple keyboard, mouse, and touchpad settings GUI application for the
-LXQt desktop environment.
-.P
-\fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
-technologies, ships several core desktop components, all of which are optional:
-.P
- * Panel
- * Desktop
- * Application launcher
- * Settings center \fI(related to this)\fR
- * Session handler
- * Polkit handler
- * SSH password access
- * Display manager handler
-.P
-These components perform similar actions to those available in other desktop
-environments, and their name is self-descriptive.  They are usually not launched
-by hand but automatically, when choosing a \fBLXQt\-qt\fR session in the Display
-Manager.
+This is a simple GUI application for keyboard, mouse, and touchpad settings.
+(Currently it can only run under X11.)
 .P
 .SH "REPORTING BUGS"
-Report bugs to https://github.com/lxqt/lxqt/issues
+Report bugs to https://github.com/lxqt/lxqt-config/issues
 .SH "SEE ALSO"
 \fBLXQt\fR has been tailored for users who value simplicity, speed, and
 an intuitive interface, also intended for less powerful machines. See also:
 .\" any module must refers to session app, for more info on start it
 .P
-\fBlxqt-config(1)\fR  LXQt application for performing settings on many applications
-.P
-.SH AUTHOR
-This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
-for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.
+\fBlxqt-config(1)\fR  LXQt Configuration Center

--- a/liblxqt-config-cursor/man/lxqt-config-input.1
+++ b/liblxqt-config-cursor/man/lxqt-config-input.1
@@ -1,12 +1,13 @@
 .TH lxqt-config-cursor "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ Cursor settings"
 .SH NAME
-lxqt-config-cursor \- Application of \fBLXQt\fR: the faster and lighter Qt Desktop Environment
+lxqt-config-input \- Application of \fBLXQt\fR: the faster and lighter Qt Desktop
+Environment
 .SH SYNOPSIS
-.B lxqt-config-cursor
+.B lxqt-config-input
 .br
 .SH DESCRIPTION
-This is a simple GUI cursor theme configuration (at the moment) for the LXQt desktop environment.
-Also can manage theme installation for it (locally for/per user only).
+This is a simple GUI keyboard, mouse, and touchpad settings application for the
+LXQt desktop environment.
 .P
 \fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
 technologies, ships several core desktop components, all of which are optional:

--- a/liblxqt-config-cursor/man/lxqt-config-input.1
+++ b/liblxqt-config-cursor/man/lxqt-config-input.1
@@ -1,4 +1,4 @@
-.TH lxqt-config-cursor "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ Cursor settings"
+.TH lxqt-config-input "1" "January 2025" "LXQt 2.1.0" "LXQt Input Settings"
 .SH NAME
 lxqt-config-input \- Application of \fBLXQt\fR: the faster and lighter Qt Desktop
 Environment

--- a/lxqt-config-appearance/man/lxqt-config-appearance.1
+++ b/lxqt-config-appearance/man/lxqt-config-appearance.1
@@ -1,5 +1,4 @@
-.TH lxqt-config-appearance "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ GUI
-settings"
+.TH lxqt-config-appearance "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ GUI settings"
 .SH NAME
 lxqt-config-appearance \- GUI appearance application of \fBLXQt\fR: the fast
 and lightweight Qt Desktop Environment
@@ -10,8 +9,8 @@ and lightweight Qt Desktop Environment
 With this application you can set and configure the Qt/LXQt GUI appearance of
 programs.
 .P
-In Linux, the look of a GUI application depends on the toolkit it is based on.
-in LXQt, the overall look of many apps relies on the Qt framework GUI. The
+On Linux/Unix, the look of a GUI application depends on the toolkit it is based on.
+For LXQt, the overall look of many apps relies on the Qt framework GUI. The
 \fBlxqt-config-appearance\fR application provides all aspects of configuring the
 appearance of the \fBLXQt\fR desktop.
 .P

--- a/lxqt-config-appearance/man/lxqt-config-appearance.1
+++ b/lxqt-config-appearance/man/lxqt-config-appearance.1
@@ -1,4 +1,4 @@
-.TH lxqt-config-appearance "1" "January 2025" "LXQt 2.1.0" "LXQt Appearance Settings"
+.TH LXQT-CONFIG-APPEARANCE "1" "January 2025" "LXQt 2.1.0" "LXQt Appearance Settings"
 .SH NAME
 lxqt-config-appearance \- GUI appearance application of \fBLXQt\fR: The Lightweight
 Qt Desktop Environment
@@ -31,6 +31,6 @@ Report bugs to https://github.com/lxqt/lxqt-config/issues
 an intuitive interface. LXQt is also intended for less powerful machines. Also,
 See:
 .P
-\fBlxqt-session.1\fR  LXQt Session Manager
-.P
-\fBlxqt-config.1\fR  LXQt Configuration Center
+\fBlxqt-session(1)\fR  LXQt Session Manager
+.br
+\fBlxqt-config(1)\fR   LXQt Configuration Center

--- a/lxqt-config-appearance/man/lxqt-config-appearance.1
+++ b/lxqt-config-appearance/man/lxqt-config-appearance.1
@@ -1,13 +1,14 @@
 .TH lxqt-config-appearance "1" "January 2025" "LXQt 2.1.0" "LXQt Appearance Settings"
 .SH NAME
-lxqt-config-appearance \- GUI appearance application of \fBLXQt\fR: the fast
-and lightweight Qt Desktop Environment
+lxqt-config-appearance \- GUI appearance application of \fBLXQt\fR: The Lightweight
+Qt Desktop Environment
 .SH SYNOPSIS
 .B lxqt-config-appearance
 .br
 .SH DESCRIPTION
-With this application you can set and configure the Qt/LXQt GUI appearance of
-programs.
+With this application you can set and configure the Qt / LXQt GUI appearance. Options
+include configuring widget style, color palette, application toolbar, icon theme,
+LXQt theme, font, cursor, and optionally GTK 2/3 style.
 .P
 On Linux/Unix, the look of a GUI application depends on the toolkit it is based on.
 For LXQt, the overall look of many apps relies on the Qt framework GUI. The
@@ -17,37 +18,13 @@ appearance of the \fBLXQt\fR desktop.
 All the remaining major aspects of LXQt appearance rely on the active Qt widget
 style because the \fBLXQt\fR DE is based on the Qt framework.
 .P
-\fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
-technologies and ships several core desktop components, all of which are
-optional:
-.P
- * Panel
- * Desktop
- * Application launcher
- * Settings center \fI(related to this)\fR
- * Session handler
- * Polkit handler
- * SSH password manager
- * Display manager handler
- * Power manager
-.P
-These components perform actions like their counterparts in other desktop
-environments and their names are self-descriptive. They are usually not
-launched manually but automatically, when an \fBLXQt\fR session is chosen in the
-Display Manager.
-.P
 .SH "REPORTING BUGS"
-Report bugs to https://github.com/lxqt/lxqt/issues
+Report bugs to https://github.com/lxqt/lxqt-config/issues
 .SH "SEE ALSO"
 \fBLXQt\fR it has been tailored for users who value simplicity, speed, and
 an intuitive interface. LXQt is also intended for less powerful machines. Also,
 See:
-.\" any module must refer to session app, for more info on starting it
 .P
-\fBlxqt-session.1\fR  LXQt module for managing the LXQt environment.
+\fBlxqt-session.1\fR  LXQt Session Manager
 .P
-\fBlxqt-config.1\fR  LXQt application for general config and settings.
-.P
-.SH AUTHOR
-This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
-for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.
+\fBlxqt-config.1\fR  LXQt Configuration Center

--- a/lxqt-config-appearance/man/lxqt-config-appearance.1
+++ b/lxqt-config-appearance/man/lxqt-config-appearance.1
@@ -1,4 +1,4 @@
-.TH lxqt-config-appearance "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ GUI settings"
+.TH lxqt-config-appearance "1" "January 2025" "LXQt 2.1.0" "LXQt Appearance Settings"
 .SH NAME
 lxqt-config-appearance \- GUI appearance application of \fBLXQt\fR: the fast
 and lightweight Qt Desktop Environment

--- a/lxqt-config-appearance/man/lxqt-config-appearance.1
+++ b/lxqt-config-appearance/man/lxqt-config-appearance.1
@@ -18,6 +18,12 @@ appearance of the \fBLXQt\fR desktop.
 All the remaining major aspects of LXQt appearance rely on the active Qt widget
 style because the \fBLXQt\fR DE is based on the Qt framework.
 .P
+.SH OPTIONS
+-v, --version  Displays version information.
+.br
+-h, --help     Displays help on command line options.
+.br
+--help-all     Displays help, including generic Qt options.
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxqt/lxqt-config/issues
 .SH "SEE ALSO"

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -1,4 +1,4 @@
-.TH lxqt-config "1" "January 2025" "LXQt 2.1.0" "LXQt Configuration Center"
+.TH LXQT-CONFIG "1" "January 2025" "LXQt 2.1.0" "LXQt Configuration Center"
 .SH NAME
 lxqt-config \- \fBLXQt\fR Configuration Center for all related modules and
 applications

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -1,4 +1,4 @@
-.TH lxqt-config "1" "September 2012" "LXQt 0.7.0" "LXQt System Settings"
+.TH lxqt-config "1" "January 2025" "LXQt 2.1.0" "LXQt Configuration Center"
 .SH NAME
 lxqt-config \- \fBLXQt\fR Configuration Center for all related modules and
 applications

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -24,6 +24,7 @@ desktop environment.
  * Power Management settings: (\fBlxqt-config-powermanagement\fR)
  * File Associations settings: (\fBlxqt-config-file-associations\fR)
  * Global Shortcuts settings: (\fBlxqt-config-globalkeyshortcuts\fR)
+ * Desktop settings: (\fBpcmanfm-qt --desktop-pref=general\fR)
 .P
 Additionally, if present, other non-LXQt settings applications appear in the
 Configuration Center under the categories "Other Settings" and "System Settings".

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -27,7 +27,7 @@ environments and their names are self-descriptive. They are usually not
 launched manually but automatically, when an \fBLXQt\fR session is chosen in the
 Display Manager.
 .P
-.SH LXQt Settings Center related applications
+.SH LXQt Settings Applications
 .P
 \fBLXQt\fR has various config applications:
 .P
@@ -41,6 +41,9 @@ Display Manager.
  * Power Management settings: (\fBlxqt-config-powermanagement\fR)
  * File Associations settings: (\fBlxqt-config-file-associations\fR)
  * Global Shortcuts settings: (\fBlxqt-config-globalkeyshortcuts\fR)
+.P
+Additionally, if present, other non-LXQt settings applications appear in the
+Configuration Center under the categories "Other Settings" and "System Settings".
 .P
 These applications can also be found in the Settings or Preferences menu; please
 consult the respective manpages.

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -10,23 +10,6 @@ This application is a settings center for all environment related applications
 and all configuration software installed and registered by the \fBLXQt\fR
 desktop environment.
 .P
-\fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
-technologies and ships several core desktop components, all of which are
-optional:
-.P
- * Panel
- * Desktop
- * Application launcher
- * Configuration center \fI(this)\fR
- * Session handler
- * Polkit handler
- * SSH password access
-.P
-These components perform actions like their counterparts in other desktop
-environments and their names are self-descriptive. They are usually not
-launched manually but automatically, when an \fBLXQt\fR session is chosen in the
-Display Manager.
-.P
 .SH LXQt Settings Applications
 .P
 \fBLXQt\fR has various config applications:
@@ -47,18 +30,23 @@ Configuration Center under the categories "Other Settings" and "System Settings"
 .P
 These applications can also be found in the Settings or Preferences menu; please
 consult the respective manpages.
+.P
+.SH OPTIONS
+-v, --version  Displays version information.
+.br
+-h, --help     Displays help on command line options.
+.br
+--help-all     Displays help, including generic Qt options.
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxqt/lxqt-config/issues
 .SH "SEE ALSO"
 \fBLXQt\fR has been tailored for users who value simplicity, speed, and an
 intuitive interface. LXQt is also intended for less powerful machines. See:
-
-.\" any module must refer to session app, for more info on starting it
 .P
  * Input settings: \fBlxqt-config-input(1)\fR
-.P
+.br
  * Appearance settings: \fBlxqt-config-appearance(1)\fR
-.P
+.br
  * Session settings: \fBlxqt-config-session(1)\fR
-.P
+.br
  * Notification settings: \fBlxqt-config-notificationd(1)\fR

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -1,14 +1,14 @@
 .TH lxqt-config "1" "September 2012" "LXQt 0.7.0" "LXQt System Settings"
 .SH NAME
-lxqt-config \- \fBLXQt\fR Settings Center for all related modules and
+lxqt-config \- \fBLXQt\fR Configuration Center for all related modules and
 applications
 .SH SYNOPSIS
 .B lxqt-config
 .br
 .SH DESCRIPTION
 This application is a settings center for all environment related applications
-and all config software installed and registered by the \fBLXQt\fR desktop
-environment.
+and all configuration software installed and registered by the \fBLXQt\fR
+desktop environment.
 .P
 \fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
 technologies and ships several core desktop components, all of which are
@@ -32,14 +32,19 @@ Display Manager.
 .P
 \fBLXQt\fR has various config applications:
 .P
- * Mouse settings: (\fBlxqt-config-mouse\fR)
- * Desktop settings: (\fBlxqt-config-desktop\fR)
+ * Keyboard and Mouse settings: (\fBlxqt-config-input\fR)
+ * Brightness settings: (\fBlxqt-config-brightness\fR)
  * Appearance settings: (\fBlxqt-config-appearance\fR)
  * Session settings: (\fBlxqt-config-session\fR)
  * Notification settings: (\fBlxqt-config-notificationd\fR)
+ * Monitor settings: (\fBlxqt-config-monitor\fR)
+ * Locale settings: (\fBlxqt-config-locale\fR)
+ * Power Management settings: (\fBlxqt-config-powermanagement\fR)
+ * File Associations settings: (\fBlxqt-config-file-associations\fR)
+ * Global Shortcuts settings: (\fBlxqt-config-globalkeyshortcuts\fR)
 .P
-All of this can also be found in Settings or Preferences menu; please consult
-the respective manpages.
+These applications can also be found in the Settings or Preferences menu; please
+consult the respective manpages.
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxqt/lxqt/issues
 .SH "SEE ALSO"
@@ -48,9 +53,7 @@ intuitive interface. LXQt is also intended for less powerful machines. See:
 
 .\" any module must refer to session app, for more info on starting it
 .P
- * Mouse settings: \fBlxqt-config-mouse(1)\fR
-.P
- * Desktop settings: \fBlxqt-config-desktop(1)\fR
+ * Keyboard and Mouse settings: \fBlxqt-config-input(1)\fR
 .P
  * Appearance settings: \fBlxqt-config-appearance(1)\fR
 .P

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -31,7 +31,7 @@ Display Manager.
 .P
 \fBLXQt\fR has various config applications:
 .P
- * Keyboard and Mouse settings: (\fBlxqt-config-input\fR)
+ * Input settings: (\fBlxqt-config-input\fR)
  * Brightness settings: (\fBlxqt-config-brightness\fR)
  * Appearance settings: (\fBlxqt-config-appearance\fR)
  * Session settings: (\fBlxqt-config-session\fR)
@@ -48,21 +48,17 @@ Configuration Center under the categories "Other Settings" and "System Settings"
 These applications can also be found in the Settings or Preferences menu; please
 consult the respective manpages.
 .SH "REPORTING BUGS"
-Report bugs to https://github.com/lxqt/lxqt/issues
+Report bugs to https://github.com/lxqt/lxqt-config/issues
 .SH "SEE ALSO"
 \fBLXQt\fR has been tailored for users who value simplicity, speed, and an
 intuitive interface. LXQt is also intended for less powerful machines. See:
 
 .\" any module must refer to session app, for more info on starting it
 .P
- * Keyboard and Mouse settings: \fBlxqt-config-input(1)\fR
+ * Input settings: \fBlxqt-config-input(1)\fR
 .P
  * Appearance settings: \fBlxqt-config-appearance(1)\fR
 .P
  * Session settings: \fBlxqt-config-session(1)\fR
 .P
  * Notification settings: \fBlxqt-config-notificationd(1)\fR
-.P
-.SH AUTHOR
-This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
-for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.

--- a/man/lxqt-config.1
+++ b/man/lxqt-config.1
@@ -17,11 +17,10 @@ optional:
  * Panel
  * Desktop
  * Application launcher
- * Settings center \fI(this)\fR
+ * Configuration center \fI(this)\fR
  * Session handler
  * Polkit handler
  * SSH password access
- * Display manager handler
 .P
 These components perform actions like their counterparts in other desktop
 environments and their names are self-descriptive. They are usually not


### PR DESCRIPTION
There were several problems including references to `lxqt-config-mouse` and `lxqt-config-desktop`, and a broken title.