### PR TITLE
Improved locale setting

### DIFF
--- a/lxqt-config-locale/localeconfig.h
+++ b/lxqt-config-locale/localeconfig.h
@@ -51,14 +51,14 @@ public:
 
     void load();
     void save();
-    void defaults();
 
 public slots:
     void initControls();
     void saveSettings();
 
 private:
-    void addLocaleToCombo(QComboBox *combo, const QLocale &locale);
+    void addLocaleToCombo(QComboBox *combo, const QLocale &locale, bool currentLocale = false);
+    QString getCurrentforCombo(QComboBox *combo);
     void initCombo(QComboBox *combo, const QList<QLocale> &allLocales);
     void connectCombo(QComboBox *combo);
     QList<QComboBox *> m_combos;

--- a/lxqt-config-locale/localeconfig.ui
+++ b/lxqt-config-locale/localeconfig.ui
@@ -304,7 +304,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="lexMeasurement_2">
+           <widget class="QLabel" name="lexMeasurement">
             <property name="text">
              <string>Measurement Units:</string>
             </property>


### PR DESCRIPTION
The following changes are made:

 * The first item of each list is "Unset", which means that LXQt won't set the corresponding locale with the next session. It serves as a cleaner.
 * The second item shows the locale of the *current* session ("Current: …"), which may be different from saved locales. It may not be the system default either (because session locales can be set in various ways).
 * A separator is added after the current locale. Its look depends on the Qt widget style.
 * When the app is launched, the combos show their saved or current values, depending on whether they are saved or not.

Closes https://github.com/lxqt/lxqt-config/issues/1093