### PR TITLE
Optimized LXQt Locale Configuration

### DIFF
--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -156,7 +156,9 @@ QString LocaleConfig::getCurrentforCombo(QComboBox *combo)
 void LocaleConfig::initCombo(QComboBox *combo, const QList<QLocale> & allLocales)
 {
     combo->clear();
-    combo->setInsertPolicy(QComboBox::InsertAlphabetically);
+
+    // for performance reason
+    combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
 
     // set the first item to "Unset"
     combo->addItem(tr("Unset"), QString());
@@ -203,7 +205,15 @@ void LocaleConfig::addLocaleToCombo(QComboBox *combo, const QLocale &locale, boo
     QIcon flagIcon;
     if (!flag.isEmpty())
     {
-        flagIcon = QIcon(flag);
+        if (!mFlags.contains(flag))
+        {
+            flagIcon = QIcon(flag);
+            mFlags.insert(flag, flagIcon);
+        }
+        else
+        {
+            flagIcon = mFlags.value(flag);
+        }
     }
 
     QString itemResult;
@@ -356,7 +366,7 @@ void LocaleConfig::saveSettings()
 {
     if (hasChanged)
     {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setWindowTitle(tr("Format Settings Changed"));
         msgBox.setText(tr("Do you want to save your changes? They will take effect the next time you log in."));
         msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Cancel);
@@ -522,6 +532,9 @@ void LocaleConfig::updateExample()
     m_ui->exampleTimeShort->setText(timeExampleShort);
     m_ui->exampleCurrency->setText(currencyExample);
     m_ui->exampleMeasurement->setText(measurementSetting);
+
+    // this is especially needed on Wayland for preventing a truncated time label
+    m_ui->exampleBox->adjustSize();
 }
 
 void LocaleConfig::initControls()

--- a/lxqt-config-locale/localeconfig.h
+++ b/lxqt-config-locale/localeconfig.h
@@ -73,6 +73,7 @@ private:
     bool hasChanged;
     LXQt::Settings *mSettings;
     LXQt::Settings *sSettings;
+    QHash<const QString, QIcon>mFlags;
 };
 
 #endif // LOCALECONFIG_H


### PR DESCRIPTION
 1. Previously, each flag icon was created at least 6 times, for six combo-boxes. That caused a considerable delay on launching. Now each icon is created only once and is cached.
 2. The size policy of combo-boxes is changed to what Qt recommends for large lists, namely, `QComboBox::AdjustToMinimumContentsLengthWithIcon`.
 3. A truncated time label is prevented in the Examples box on showing the dialog under Wayland.
 4. The prompt dialog is now the child of the main dialog, such that a Wayland compositor like Labwc centers the former in front of the latter (other compositors may need to learn from Labwc).

Because of 2, there may be a delay the first time the list of a combo-box is shown by the user, but (1) there will be no delay afterward, and (2) the user even doesn't need to show the list — searching by typing was implemented years ago. Previously, that delay happened on launching.