### PR TITLE
lxqt-config-appearance: Add colon to remaining labels

### DIFF
--- a/lxqt-config-appearance/gtkconfig.ui
+++ b/lxqt-config-appearance/gtkconfig.ui
@@ -74,7 +74,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
-               <string>GTK 2 Theme</string>
+               <string>GTK 2 Theme:</string>
               </property>
              </widget>
             </item>
@@ -90,7 +90,7 @@
                </sizepolicy>
               </property>
               <property name="text">
-               <string>GTK 3 Theme</string>
+               <string>GTK 3 Theme:</string>
               </property>
              </widget>
             </item>

--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -48,7 +48,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
-            <string>Qt Style</string>
+            <string>Qt Style:</string>
            </property>
           </widget>
          </item>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ar.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ar.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>سمة جتك ٣</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>سمة جتك ٣:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>سمة جتك ٢</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>سمة جتك ٢:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>نمط كيوت</translation>
+        <source>Qt Style:</source>
+        <translation>نمط كيوت:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_arn.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_arn.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ast.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ast.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_bg.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_bg.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK Стил 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK Стил 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK Стил 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK Стил 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Стил на Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Стил на Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ca.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ca.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema de GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema de GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema de GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema de GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Assegureu-vos que «xsettingsd» està instal·lat perquè ajudi a les aplicacio
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Estil Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Estil Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_cs.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_cs.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 motiv vzhledu</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 motiv vzhledu:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 motiv vzhledu</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 motiv vzhledu:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Aby bylo možné u GTK aplikací změnit motiv vzhledu za chodu, ověřte, že j
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt styl</translation>
+        <source>Qt Style:</source>
+        <translation>Qt styl:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_cy.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_cy.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_da.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_da.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3-tema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3-tema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2-tema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2-tema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Sørg for at &apos;xsettingsd&apos; er installeret, for at hjælpe GTK programme
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt-stil</translation>
+        <source>Qt Style:</source>
+        <translation>Qt-stil:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_de.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_de.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3-Thema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3-Thema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2-Thema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2-Thema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt-Stil</translation>
+        <source>Qt Style:</source>
+        <translation>Qt-Stil:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_el.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_el.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Θέμα GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Θέμα GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Θέμα GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Θέμα GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Τεχνοτροπία Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Τεχνοτροπία Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_en_GB.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_en_GB.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_eo.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_eo.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_es.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_es.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema para GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema para GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema para GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema para GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Asegúrese de que esté instalado &apos;xsettingsd&apos; para hacer que las apli
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Estilo de Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Estilo de Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_es_VE.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_es_VE.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_et.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_et.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 teema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 teema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 teema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 teema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Kui soovid GTK-põhiste rakenduste välimust lennult muuta, siis palun kontrolli
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt stiil</translation>
+        <source>Qt Style:</source>
+        <translation>Qt stiil:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_eu.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_eu.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 gaia</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 gaia:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 Gaia</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 Gaia:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt estiloa</translation>
+        <source>Qt Style:</source>
+        <translation>Qt estiloa:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_fa.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_fa.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_fi.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_fi.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 -teema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 -teema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 -teema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 -teema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Varmista että &apos;xsettingsd&apos; on asennettu helpottaaksesi GTK-ohjelmien 
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt-tyyli</translation>
+        <source>Qt Style:</source>
+        <translation>Qt-tyyli:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_fr.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_fr.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Thème GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Thème GTK 3 :</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Thème GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Thème GTK 2 :</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Style QT</translation>
+        <source>Qt Style:</source>
+        <translation>Style QT :</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_gl.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_gl.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema para GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema para GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema para GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema para GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Asegúrese de que «xsettingsd» está instalado para axudar ás aplicacións GT
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Estilo de Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Estilo de Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_he.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_he.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>ערכת עיצוב GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>ערכת עיצוב GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>ערכת עיצוב GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>ערכת עיצוב GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>סגנון Qt</translation>
+        <source>Qt Style:</source>
+        <translation>סגנון Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_hi.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_hi.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 थीम</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 थीम:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 थीम</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 थीम:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_hr.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_hr.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 tema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 tema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 tema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 tema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Uvjeri se da je „xsettingsd” instaliran, koji GTK programima pomaže trenutn
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt stil</translation>
+        <source>Qt Style:</source>
+        <translation>Qt stil:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_hu.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_hu.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 téma</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 téma:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 téma</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 téma:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Győződjön meg arról, hogy az &apos;xsettingsd&apos; telepítve van, hogy a G
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt stílus</translation>
+        <source>Qt Style:</source>
+        <translation>Qt stílus:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ia.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ia.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_id.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_id.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -458,8 +458,8 @@ Pastikan &apos;xsettingsd&apos; terinstal agar aplikasi GTK dapat membantu mener
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Gaya Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Gaya Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_it.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_it.ts
@@ -176,13 +176,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -460,8 +460,8 @@ Assicurati che &apos;xsettingsd&apos; sia installato per aiutare le applicazioni
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Stile Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Stile Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ja.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ja.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK3 テーマ</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK3 テーマ:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK2 テーマ</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK2 テーマ:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt スタイル</translation>
+        <source>Qt Style:</source>
+        <translation>Qt スタイル:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ka.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ka.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3-ის თემა</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3-ის თემა:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2-ის თემა</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2-ის თემა:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt-ის სტილი</translation>
+        <source>Qt Style:</source>
+        <translation>Qt-ის სტილი:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_kab.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_kab.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_kk.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_kk.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 рәсімдеу тәсілі</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 рәсімдеу тәсілі:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 рәсімдеу тәсілі</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 рәсімдеу тәсілі:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,7 +459,7 @@ GTK бағдарламалары рәсімдеу стильдерін бірд�
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ko.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ko.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 테마</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 테마:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 테마</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 테마:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ GTK 응용 프로그램이 테마를 즉석에서 적용할 수 있도록 &apos;
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt 스타일</translation>
+        <source>Qt Style:</source>
+        <translation>Qt 스타일:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_lg.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_lg.ts
@@ -176,13 +176,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Lulyo lw&apos;endabika ya GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Lulyo lw&apos;endabika ya GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Lulyo lw&apos;endabika ya GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Lulyo lw&apos;endabika ya GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -463,8 +463,8 @@ ebikozesa GTK okukwata mangu endabika zino.</translation>
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Musono gw&apos;ebikozesa Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Musono gw&apos;ebikozesa Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_lt.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_lt.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 apipavidalinimas</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 apipavidalinimas:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 apipavidalinimas</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 apipavidalinimas:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt stilius</translation>
+        <source>Qt Style:</source>
+        <translation>Qt stilius:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_nb_NO.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_nb_NO.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3-tema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3-tema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2-tema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2-tema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Pass på at &apos;xsettingsd&apos; er installert for å hjelpe GTK-programmer å
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt-stil</translation>
+        <source>Qt Style:</source>
+        <translation>Qt-stil:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_nl.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_nl.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3-thema</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3-thema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2-thema</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2-thema:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Zorg dat ‘xsettingsd’ geïnstalleerd is zodat GTK-programma&apos;s meteen va
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt-stijl</translation>
+        <source>Qt Style:</source>
+        <translation>Qt-stijl:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_oc.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_oc.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Estil tèma GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Estil tèma GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Estil tèma GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Estil tèma GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -457,8 +457,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Estil Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Estil Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_pa.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_pa.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 ਥੀਮ</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 ਥੀਮ:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 ਥੀਮ</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 ਥੀਮ:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_pl.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_pl.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Motyw GTK3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Motyw GTK3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Motyw GTK2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Motyw GTK2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Upewnij się, że „xsettingsd” jest zainstalowany, aby programy GTK zmienia�
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Styl Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Styl Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_pt.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_pt.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Certifique-se de que o &apos;xsettingsd&apos; está instalado para ajudar as apl
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Estilo Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Estilo Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_pt_BR.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_pt_BR.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Verifique se o pacote &apos;xsettingsd&apos; está instalado, para permitir com 
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Estilo Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Estilo Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ro_RO.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ro_RO.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -457,8 +457,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Stil Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Stil Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_ru.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_ru.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Тема GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Тема GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Тема GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Тема GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Стиль Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Стиль Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_si.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_si.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_sk.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_sk.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Téma GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Téma GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Téma GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Téma GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Overte, či je nainštalovaný &quot;xsettingsd&quot;.</translation>
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Štýl Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Štýl Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_sl.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_sl.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Tema GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Tema GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Tema GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Tema GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Slog Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Slog Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_sr@latin.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_sr@latin.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_sr_BA.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_sr_BA.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_sr_RS.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_sr_RS.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 тема</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 тема:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 тема</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 тема:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -457,8 +457,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt Стил</translation>
+        <source>Qt Style:</source>
+        <translation>Qt Стил:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_th_TH.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_th_TH.ts
@@ -175,12 +175,12 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
+        <source>GTK 3 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
+        <source>GTK 2 Theme:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -457,7 +457,7 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
+        <source>Qt Style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_tr.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_tr.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3 Teması</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3 Teması:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2 Teması</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2 Teması:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ GTK uygulamalarının temaları anında uygulamasına yardımcı olmak için &ap
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt Biçemi</translation>
+        <source>Qt Style:</source>
+        <translation>Qt Biçemi:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_uk.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_uk.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Тема GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Тема GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Тема GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Тема GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Стиль Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Стиль Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_vi.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_vi.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>Chủ đề GTK 3</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>Chủ đề GTK 3:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>Chủ đề GTK 2</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>Chủ đề GTK 2:</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Hãy chắc là &apos;xsettingsd&apos; được cài đặt để giúp các ứ
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Phong cách Qt</translation>
+        <source>Qt Style:</source>
+        <translation>Phong cách Qt:</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_zh_CN.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_zh_CN.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3主题</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3主题：</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2主题</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2主题：</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt风格</translation>
+        <source>Qt Style:</source>
+        <translation>Qt风格：</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>

--- a/lxqt-config-appearance/translations/lxqt-config-appearance_zh_TW.ts
+++ b/lxqt-config-appearance/translations/lxqt-config-appearance_zh_TW.ts
@@ -175,13 +175,13 @@
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="93"/>
-        <source>GTK 3 Theme</source>
-        <translation>GTK 3主題</translation>
+        <source>GTK 3 Theme:</source>
+        <translation>GTK 3主題：</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="77"/>
-        <source>GTK 2 Theme</source>
-        <translation>GTK 2主題</translation>
+        <source>GTK 2 Theme:</source>
+        <translation>GTK 2主題：</translation>
     </message>
     <message>
         <location filename="../gtkconfig.ui" line="103"/>
@@ -459,8 +459,8 @@ Make sure &apos;xsettingsd&apos; is installed to help GTK applications apply the
     </message>
     <message>
         <location filename="../styleconfig.ui" line="51"/>
-        <source>Qt Style</source>
-        <translation>Qt風格</translation>
+        <source>Qt Style:</source>
+        <translation>Qt風格：</translation>
     </message>
     <message>
         <location filename="../styleconfig.cpp" line="330"/>


### PR DESCRIPTION
There were only three labels missing colons in lxqt-config-appearance. As far as the rest of lxqt-config goes, it looked like there weren't any more.

**Steps:**
1. Modify (three) .ui strings
2. `sed -i 's/<source>Qt Style<\/source>/<source>Qt Style:<\/source>/g' translations/*`
3. `sed -i 's/<source>GTK 2 Theme<\/source>/<source>GTK 2 Theme:<\/source>/g' translations/*`
4. `sed -i 's/<source>GTK 3 Theme<\/source>/<source>GTK 3 Theme:<\/source>/g' translations/*`
5. Manualy append colons in the exact manner as https://github.com/lxqt/libfm-qt/pull/1033
   (Except for zh_* which used a full-width colon.)
