### PR TITLE
Appearance - GTK Style: Move information label out of QFormLayout

### DIFF
--- a/lxqt-config-appearance/gtkconfig.ui
+++ b/lxqt-config-appearance/gtkconfig.ui
@@ -71,17 +71,17 @@
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
            <layout class="QFormLayout" name="formLayout_2">
-            <item row="1" column="0">
+            <item row="0" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
                <string>GTK 2 Theme:</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
+            <item row="0" column="1">
              <widget class="QComboBox" name="gtk2ComboBox"/>
             </item>
-            <item row="2" column="0">
+            <item row="1" column="0">
              <widget class="QLabel" name="label_4">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -94,7 +94,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="1" column="1">
              <widget class="QComboBox" name="gtk3ComboBox"/>
             </item>
            </layout>

--- a/lxqt-config-appearance/gtkconfig.ui
+++ b/lxqt-config-appearance/gtkconfig.ui
@@ -97,19 +97,19 @@
             <item row="2" column="1">
              <widget class="QComboBox" name="gtk3ComboBox"/>
             </item>
-            <item row="3" column="1">
-             <widget class="QLabel" name="uniformThemeLabel">
-              <property name="text">
-               <string>To attempt uniform theming, either select similar style/theme (if available) across all lists, or select 'gtk2' Qt style (if available) to mimic GTK themes.
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="uniformThemeLabel">
+            <property name="text">
+             <string>To attempt uniform theming, either select similar style/theme (if available) across all lists, or select 'gtk2' Qt style (if available) to mimic GTK themes.
 
 Make sure 'xsettingsd' is installed to help GTK applications apply themes on the fly.</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Move information label outside of the QFormLayout.

It looked weird being aligned to one column.