### PR TITLE
Apply cursor changes to GTK in `lxqt-config-input` if needed

### DIFF
--- a/liblxqt-config-cursor/selectwnd.cpp
+++ b/liblxqt-config-cursor/selectwnd.cpp
@@ -52,6 +52,8 @@ SelectWnd::SelectWnd(LXQt::Settings* settings, QWidget *parent)
     ui->preview->setCurrentCursorSize(getDefaultCursorSize());
     ui->preview->setCursorSize(ui->preview->getCurrentCursorSize());
 
+    ui->extraInfoLabel->hide();
+
     mModel = new XCursorThemeModel(this);
 
     int size = style()->pixelMetric(QStyle::PM_LargeIconSize);
@@ -253,4 +255,18 @@ void SelectWnd::cursorSizeChanged(int size)
 {
     ui->preview->setCursorSize(size);
     emit settingsChanged();
+}
+
+void SelectWnd::showExtraInfo(const QString& info)
+{
+    if (info.isEmpty())
+    {
+        ui->extraInfoLabel->clear();
+        ui->extraInfoLabel->hide();
+    }
+    else
+    {
+        ui->extraInfoLabel->setText(info);
+        ui->extraInfoLabel->show();
+    }
 }

--- a/liblxqt-config-cursor/selectwnd.h
+++ b/liblxqt-config-cursor/selectwnd.h
@@ -38,6 +38,8 @@ public:
 
     void applyCusorTheme();
 
+    void showExtraInfo(const QString& info);
+
 public slots:
     void setCurrent ();
 

--- a/liblxqt-config-cursor/selectwnd.ui
+++ b/liblxqt-config-cursor/selectwnd.ui
@@ -112,6 +112,16 @@
      </property>
     </widget>
    </item>
+   <item row="6" column="0" colspan="5">
+    <widget class="QLabel" name="extraInfoLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -35,6 +35,7 @@ set(lxqt-config-input_HDRS
     mouseconfig.h
     keyboardlayoutconfig.h
     selectkeyboardlayoutdialog.h
+    ../lxqt-config-appearance/configothertoolkits.h
 )
 
 set(lxqt-config-input_SRCS
@@ -43,6 +44,7 @@ set(lxqt-config-input_SRCS
     mouseconfig.cpp
     keyboardlayoutconfig.cpp
     selectkeyboardlayoutdialog.cpp
+    ../lxqt-config-appearance/configothertoolkits.cpp
 )
 
 set(lxqt-config-input_UIS

--- a/lxqt-config-input/mouseconfig.cpp
+++ b/lxqt-config-input/mouseconfig.cpp
@@ -60,9 +60,12 @@ MouseConfig::MouseConfig(LXQt::Settings* _settings, QSettings* _qtSettings, QWid
   connect(ui.singleClick, &QAbstractButton::clicked, this, &MouseConfig::settingsChanged);
 
   if (QGuiApplication::platformName() == QLatin1String("wayland"))
-  { // disable the settings that don't work under Wayland
+  { // disable the settings that don't work under Wayland and show the extra info
     ui.mouseLeftHanded->setEnabled(false);
+    ui.extraInfoLabel->setText(QStringLiteral("\n") + tr("Use the settings of the Wayland compositor for more options about mouse, touchpad and keyboard."));
   }
+  else
+    ui.extraInfoLabel->hide();
 }
 
 MouseConfig::~MouseConfig() {

--- a/lxqt-config-input/mouseconfig.ui
+++ b/lxqt-config-input/mouseconfig.ui
@@ -65,6 +65,13 @@
      </property>
     </widget>
    </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QLabel" name="extraInfoLabel">
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
"if needed" means if the GTK option is enabled in LXQt Appearance Configuration.

The patch also shows info on mouse/touchpad/keyboard settings under Wayland and, if the GTK option isn't enabled, a hint on GTK.