### PR TITLE
Fixed screen images with different scales in monitors page

### DIFF
--- a/lxqt-config-monitor/monitorpicture.cpp
+++ b/lxqt-config-monitor/monitorpicture.cpp
@@ -194,7 +194,8 @@ MonitorPicture::MonitorPicture(QGraphicsItem * parent,
 {
     this->monitorWidget = monitorWidget;
     this->monitorPictureDialog = monitorPictureDialog;
-    QSize currentSize = sizeFromString(monitorWidget->ui.resolutionCombo->currentText());
+    QSizeF currentSizeF = sizeFromString(monitorWidget->ui.resolutionCombo->currentText()) / monitorWidget->output->scale();
+    QSize currentSize = currentSizeF.toSize();
     if( monitorWidget->output->rotation() == KScreen::Output::Left || monitorWidget->output->rotation() == KScreen::Output::Right )
         currentSize.transpose();
     int x = monitorWidget->ui.xPosSpinBox->value();


### PR DESCRIPTION
This fix wasn't needed on X11, because all screens had the same scale factor there, but its lack can cause a gap between screens on Wayland (only kwin_wayland for now).

See https://github.com/lxqt/lxqt-config/issues/996 for the other things that need to be fixed.