### PR TITLE
lxqt-config-appearance: Add GTK 4 theming

### DIFF
--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -67,6 +67,17 @@ gtk-cursor-theme-name = %6
 gtk-cursor-theme-size = %7
 )GTK3_CONFIG";
 
+static const char *GTK4_CONFIG = R"GTK4_CONFIG(
+# Created by lxqt-config-appearance (DO NOT EDIT!)
+[Settings]
+gtk-theme-name = %1
+gtk-icon-theme-name = %2
+# GTK4 ignores bold or italic attributes.
+gtk-font-name = %3
+gtk-cursor-theme-name = %4
+gtk-cursor-theme-size = %5
+)GTK4_CONFIG";
+
 static const char *XSETTINGS_CONFIG = R"XSETTINGS_CONFIG(
 # Created by lxqt-config-appearance (DO NOT EDIT!)
 Net/IconThemeName "%2"
@@ -88,6 +99,16 @@ set org.gnome.desktop.interface font-name "%3"
 set org.gnome.desktop.interface cursor-theme "%6"
 set org.gnome.desktop.interface cursor-size "%7"
 )GTK3_GSETTINGS";
+
+static const char *GTK4_GSETTINGS = R"GTK4_GSETTINGS(
+set org.gnome.desktop.interface icon-theme "%2"
+set org.gnome.desktop.interface gtk-theme "%1"
+set org.gnome.desktop.interface font-name "%3"
+# set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ButtonImages': <%4>, 'Gtk/MenuImages': <%4>}"
+# set org.gnome.desktop.interface toolbar-style "%5"
+set org.gnome.desktop.interface cursor-theme "%6"
+set org.gnome.desktop.interface cursor-size "%7"
+)GTK4_GSETTINGS";
 
 /*
  * Button and menu images are deprecated in GTK 3.10:
@@ -197,10 +218,13 @@ void ConfigOtherToolKits::setConfig()
     setGTKConfig(QStringLiteral("2.0"));
     mConfig.styleTheme = getGTKThemeFromRCFile(QStringLiteral("3.0"));
     setGTKConfig(QStringLiteral("3.0"));
+    mConfig.styleTheme = getGTKThemeFromRCFile(QStringLiteral("4.0"));
+    setGTKConfig(QStringLiteral("4.0"));
 
     // Call to xsettings to update config
     setXSettingsConfig();
     setGsettingsConfig(QStringLiteral("3.0"));
+    setGsettingsConfig(QStringLiteral("4.0"));
 }
 
 void ConfigOtherToolKits::setXSettingsConfig()
@@ -235,6 +259,8 @@ void ConfigOtherToolKits::setGsettingsConfig(QString version, QString theme)
     QString commands;
     if(version == QLatin1String("3.0"))
         commands = getConfig(GTK3_GSETTINGS, ConfigOtherToolKits::GTK3GSETTINGS);
+    else if(version == QLatin1String("4.0"))
+        commands = getConfig(GTK4_GSETTINGS, ConfigOtherToolKits::GTK4GSETTINGS);
     for(QString command : commands.split(QStringLiteral("\n"))) {
         if(command.isEmpty() || command.startsWith(QStringLiteral("#")))
             continue;
@@ -256,8 +282,10 @@ void ConfigOtherToolKits::setGTKConfig(QString version, QString theme)
     QString gtkrcPath = getGTKConfigPath(version);
     if(version == QLatin1String("2.0"))
         writeConfig(gtkrcPath, GTK2_CONFIG, ConfigOtherToolKits::GTK2);
-    else
+    else if(version == QLatin1String("3.0"))
         writeConfig(gtkrcPath, GTK3_CONFIG, ConfigOtherToolKits::GTK3);
+    else if(version == QLatin1String("4.0"))
+        writeConfig(gtkrcPath, GTK4_CONFIG, ConfigOtherToolKits::GTK4);
 }
 
 QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherToolKits::Version version)
@@ -267,6 +295,7 @@ QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherTool
     QString cursorSize = sessionSettings->value(QStringLiteral("Mouse/cursor_size")).toString();
     delete sessionSettings;
     switch(version) {
+        case ConfigOtherToolKits::GTK4GSETTINGS:
         case ConfigOtherToolKits::GTK3GSETTINGS:
             {
                 QString toolBar;
@@ -284,6 +313,7 @@ QString ConfigOtherToolKits::getConfig(const char *configString, ConfigOtherTool
                         );
             }
             break;
+        case ConfigOtherToolKits::GTK4:
         case ConfigOtherToolKits::GTK3:
         case ConfigOtherToolKits::GTK2:
             return QString::fromUtf8(configString).arg(mConfig.styleTheme, mConfig.iconTheme,
@@ -319,7 +349,7 @@ QStringList ConfigOtherToolKits::getGTKThemes(QString version)
     QString configFile = version==QLatin1String("2.0") ? QStringLiteral("gtkrc") : QStringLiteral("gtk.css");
 
     if(version != QLatin1String("2.0")) {
-        // Insert default GTK3 themes:
+        // Insert default GTK3 and GTK4 themes:
         themeList << QStringLiteral("Adwaita") << QStringLiteral("HighContrast") << QStringLiteral("HighContrastInverse");
     }
 

--- a/lxqt-config-appearance/configothertoolkits.h
+++ b/lxqt-config-appearance/configothertoolkits.h
@@ -62,7 +62,7 @@ private:
     } mConfig;
 
     enum Version {
-        GTK2, GTK3, GTK3GSETTINGS
+        GTK2, GTK3, GTK4, GTK3GSETTINGS, GTK4GSETTINGS
     };
     void writeConfig(QString path, const char *configString, Version version);
     QString getConfig(const char *configString, Version version);

--- a/lxqt-config-appearance/gtkconfig.cpp
+++ b/lxqt-config-appearance/gtkconfig.cpp
@@ -41,6 +41,7 @@ GTKConfig::GTKConfig(LXQt::Settings *configAppearanceSettings, ConfigOtherToolKi
     connect(ui->advancedOptionsGroupBox, &QGroupBox::clicked, this, &GTKConfig::settingsChanged);
     connect(ui->gtk2ComboBox, QOverload<int>::of(&QComboBox::activated), this, &GTKConfig::settingsChanged);
     connect(ui->gtk3ComboBox, QOverload<int>::of(&QComboBox::activated), this, &GTKConfig::settingsChanged);
+    connect(ui->gtk4ComboBox, QOverload<int>::of(&QComboBox::activated), this, &GTKConfig::settingsChanged);
 }
 
 GTKConfig::~GTKConfig()
@@ -54,6 +55,7 @@ void GTKConfig::initControls()
     // Fill themes
     QStringList gtk2Themes = mConfigOtherToolKits->getGTKThemes(QStringLiteral("2.0"));
     QStringList gtk3Themes = mConfigOtherToolKits->getGTKThemes(QStringLiteral("3.*"));
+    QStringList gtk4Themes = mConfigOtherToolKits->getGTKThemes(QStringLiteral("4.*"));
 
     if(!mConfigAppearanceSettings->contains(QStringLiteral("ControlGTKThemeEnabled")))
         mConfigAppearanceSettings->setValue(QStringLiteral("ControlGTKThemeEnabled"), false);
@@ -66,9 +68,11 @@ void GTKConfig::initControls()
     // Fill GTK themes
     ui->gtk2ComboBox->addItems(gtk2Themes);
     ui->gtk3ComboBox->addItems(gtk3Themes);
+    ui->gtk4ComboBox->addItems(gtk4Themes);
 
     ui->gtk2ComboBox->setCurrentText(mConfigOtherToolKits->getGTKThemeFromRCFile(QStringLiteral("2.0")));
     ui->gtk3ComboBox->setCurrentText(mConfigOtherToolKits->getGTKThemeFromRCFile(QStringLiteral("3.0")));
+    ui->gtk4ComboBox->setCurrentText(mConfigOtherToolKits->getGTKThemeFromRCFile(QStringLiteral("4.0")));
 
     update();
 }
@@ -77,8 +81,13 @@ void GTKConfig::applyGTKStyle()
 {
     if (ui->advancedOptionsGroupBox->isChecked())
     {
+        // GTK4
+        QString themeName = ui->gtk4ComboBox->currentText();
+        mConfigOtherToolKits->setGTKConfig(QStringLiteral("4.0"), themeName);
+        if(QGuiApplication::platformName() == QStringLiteral("wayland"))
+            mConfigOtherToolKits->setGsettingsConfig(QStringLiteral("4.0"), themeName);
         // GTK3
-        QString themeName = ui->gtk3ComboBox->currentText();
+        themeName = ui->gtk3ComboBox->currentText();
         mConfigOtherToolKits->setGTKConfig(QStringLiteral("3.0"), themeName);
         if(QGuiApplication::platformName() == QStringLiteral("wayland"))
             mConfigOtherToolKits->setGsettingsConfig(QStringLiteral("3.0"), themeName);

--- a/lxqt-config-appearance/gtkconfig.ui
+++ b/lxqt-config-appearance/gtkconfig.ui
@@ -83,12 +83,6 @@
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_4">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
               <property name="text">
                <string>GTK 3 Theme:</string>
               </property>
@@ -96,6 +90,22 @@
             </item>
             <item row="1" column="1">
              <widget class="QComboBox" name="gtk3ComboBox"/>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_5">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>GTK 4 Theme:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="gtk4ComboBox"/>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
Two things I should say:
1. X11 has been tested working by me, but Wayland (and thus GSettings?) hasn't been tested.
2. Opening `gtk4-demo` gives me this warning:
```
Error setting gtk-cursor-theme-size in /home/REDACTED/.config/gtk-4.0/settings.ini:
Key file contains key “gtk-cursor-theme-size” in group “Settings” which has a value that cannot be interpreted.
```
The theme _seems_ to still work regardless, but if this actually causes any problems, and/or anyone knows how to fix this, it'd be great.