### PR TITLE
"Properly" multiple values desktop entry keys

### DIFF
--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -138,7 +138,7 @@ void TouchpadConfig::accept()
 
     LXQt::AutostartEntry autoStart(QStringLiteral("lxqt-config-touchpad-autostart.desktop"));
     XdgDesktopFile desktopFile(XdgDesktopFile::ApplicationType, QStringLiteral("lxqt-config-touchpad-autostart"), QStringLiteral("lxqt-config-input --load-touchpad"));
-    desktopFile.setValue(QStringLiteral("OnlyShowIn"), QStringLiteral("LXQt"));
+    desktopFile.setValue(QStringLiteral("OnlyShowIn"), QStringLiteral("LXQt;"));
     desktopFile.setValue(QStringLiteral("Comment"), QStringLiteral("Autostart touchpad settings for lxqt-config-input"));
     autoStart.setFile(desktopFile);
     autoStart.commit();

--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -222,7 +222,7 @@ void MonitorSettingsDialog::saveConfiguration(KScreen::ConfigPtr config)
     LXQt::AutostartEntry autoStart(QStringLiteral("lxqt-config-monitor-autostart.desktop"));
     XdgDesktopFile desktopFile(XdgDesktopFile::ApplicationType, QStringLiteral("lxqt-config-monitor-autostart"), QStringLiteral("lxqt-config-monitor -l"));
     //desktopFile.setValue("OnlyShowIn", QString(qgetenv("XDG_CURRENT_DESKTOP")));
-    desktopFile.setValue(QStringLiteral("OnlyShowIn"), QStringLiteral("LXQt"));
+    desktopFile.setValue(QStringLiteral("OnlyShowIn"), QStringLiteral("LXQt;"));
     desktopFile.setValue(QStringLiteral("Comment"), QStringLiteral("Autostart monitor settings for LXQt-config-monitor"));
     autoStart.setFile(desktopFile);
     autoStart.commit();


### PR DESCRIPTION
Terminating multiple values keys with a semicolon is optional. It's current practice though.

See https://github.com/lxqt/lxqt-session/pull/589