### PR TITLE
Add an icon to 'Open theme folder'

### DIFF
--- a/lxqt-config-appearance/lxqtthemeconfig.cpp
+++ b/lxqt-config-appearance/lxqtthemeconfig.cpp
@@ -183,6 +183,7 @@ void LXQtThemeConfig::contextMenu(const QPoint& p)
 {
     QMenu menu;
     QAction *a = menu.addAction(tr("Open theme folder"));
+    a->setIcon(QIcon::fromTheme(QStringLiteral("document-open")));
     connect(a, &QAction::triggered, [this, p] {
         doubleClicked(ui->lxqtThemeList->itemAt(p), 0);
     });


### PR DESCRIPTION
This was part of a bigger experiment to add "Open icons folder" and "Open cursors folder" context menu and double click, as https://github.com/lxqt/lxqt-config/pull/854 does for LXQt themes. The complexity seemed too much, but may be do-able in the future.

This PR trivially adds an icon.