### PR TITLE
lxqt-config-input: Change default cursor size 16->24

### DIFF
--- a/liblxqt-config-cursor/selectwnd.ui
+++ b/liblxqt-config-cursor/selectwnd.ui
@@ -78,7 +78,7 @@
       <number>128</number>
      </property>
      <property name="value">
-      <number>16</number>
+      <number>24</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
https://github.com/lxqt/lxqt-session/pull/569 changed `session.conf` `cursor_size=` from `18` to `24`. Still however `lxqt-config-input` tried to set (in the absence of a value?) `16`.