### PR TITLE
lxqt-config-input → Cursor: Remove misleading info label

### DIFF
--- a/liblxqt-config-cursor/selectwnd.cpp
+++ b/liblxqt-config-cursor/selectwnd.cpp
@@ -52,8 +52,6 @@ SelectWnd::SelectWnd(LXQt::Settings* settings, QWidget *parent)
     ui->preview->setCurrentCursorSize(getDefaultCursorSize());
     ui->preview->setCursorSize(ui->preview->getCurrentCursorSize());
 
-    ui->extraInfoLabel->hide();
-
     mModel = new XCursorThemeModel(this);
 
     int size = style()->pixelMetric(QStyle::PM_LargeIconSize);
@@ -255,18 +253,4 @@ void SelectWnd::cursorSizeChanged(int size)
 {
     ui->preview->setCursorSize(size);
     emit settingsChanged();
-}
-
-void SelectWnd::showExtraInfo(const QString& info)
-{
-    if (info.isEmpty())
-    {
-        ui->extraInfoLabel->clear();
-        ui->extraInfoLabel->hide();
-    }
-    else
-    {
-        ui->extraInfoLabel->setText(info);
-        ui->extraInfoLabel->show();
-    }
 }

--- a/liblxqt-config-cursor/selectwnd.ui
+++ b/liblxqt-config-cursor/selectwnd.ui
@@ -112,16 +112,6 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="5">
-    <widget class="QLabel" name="extraInfoLabel">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -82,12 +82,6 @@ int main(int argc, char** argv) {
 
     LXQt::Settings configAppearanceSettings(QStringLiteral("lxqt-config-appearance"));
     ConfigOtherToolKits *configOtherToolKits = nullptr;
-    bool controlGTK(configAppearanceSettings.value(QStringLiteral("ControlGTKThemeEnabled")).toBool());
-    if (controlGTK)
-    {
-        configOtherToolKits = new ConfigOtherToolKits(&qtSettings, &configAppearanceSettings, &dlg);
-        configOtherToolKits->startXsettingsd();
-    }
 
     /*** Mouse Config ***/
     MouseConfig* mouseConfig = new MouseConfig(&settings, &qtSettings, &dlg);
@@ -104,8 +98,6 @@ int main(int argc, char** argv) {
     QObject::connect(cursorConfig, &SelectWnd::settingsChanged, &dlg, [&dlg] {
         dlg.enableButton(QDialogButtonBox::Apply, true);
     });
-    if (!controlGTK)
-        cursorConfig->showExtraInfo(QStringLiteral("\n") + QObject::tr("To apply the changes also to GTK, check LXQt Appearance Configuration → GTK Style."));
 
     /*** Keyboard Config ***/
     KeyboardConfig* keyboardConfig = new KeyboardConfig(&settings, &qtSettings, &dlg);


### PR DESCRIPTION
Setting the cursor writes to `.gtkrc-2.0` and `.config/gtk-3.0/settings.ini` - these files override current GTK2/3 theme settings. So there's no possibility of a GTK theme overriding what is set here, making the label misleading.