### PR TITLE
Fix 'Open theme folder' context menu showing on empty space

### DIFF
--- a/lxqt-config-appearance/lxqtthemeconfig.cpp
+++ b/lxqt-config-appearance/lxqtthemeconfig.cpp
@@ -189,6 +189,7 @@ void LXQtThemeConfig::contextMenu(const QPoint& p)
     connect(a, &QAction::triggered, [this, p] {
         doubleClicked(ui->lxqtThemeList->itemAt(p), 0);
     });
+    menu.exec(ui->lxqtThemeList->viewport()->mapToGlobal(p));
 }
 
 void LXQtThemeConfig::loadThemePalette()

--- a/lxqt-config-appearance/lxqtthemeconfig.cpp
+++ b/lxqt-config-appearance/lxqtthemeconfig.cpp
@@ -181,13 +181,14 @@ void LXQtThemeConfig::doubleClicked(QTreeWidgetItem *item, int /*column*/)
 
 void LXQtThemeConfig::contextMenu(const QPoint& p)
 {
+    if (!ui->lxqtThemeList->itemAt(p))
+        return;
+
     QMenu menu;
     QAction *a = menu.addAction(tr("Open theme folder"));
     connect(a, &QAction::triggered, [this, p] {
         doubleClicked(ui->lxqtThemeList->itemAt(p), 0);
     });
-    if (ui->lxqtThemeList->itemAt(p))
-        menu.exec(ui->lxqtThemeList->viewport()->mapToGlobal(p));
 }
 
 void LXQtThemeConfig::loadThemePalette()

--- a/lxqt-config-appearance/lxqtthemeconfig.cpp
+++ b/lxqt-config-appearance/lxqtthemeconfig.cpp
@@ -186,7 +186,8 @@ void LXQtThemeConfig::contextMenu(const QPoint& p)
     connect(a, &QAction::triggered, [this, p] {
         doubleClicked(ui->lxqtThemeList->itemAt(p), 0);
     });
-    menu.exec(ui->lxqtThemeList->viewport()->mapToGlobal(p));
+    if (ui->lxqtThemeList->itemAt(p))
+        menu.exec(ui->lxqtThemeList->viewport()->mapToGlobal(p));
 }
 
 void LXQtThemeConfig::loadThemePalette()


### PR DESCRIPTION
Was part of https://github.com/lxqt/lxqt-config/pull/1131

Prevents the context menu from showing on empty space (no theme)

**Steps to reproduce**
1. Open lxqt-config-appearance → LXQt Theme, and make the window big
2. Right-click on empty space inside the QTreeWidget