### PR TITLE
Assign application chooser to the parent window

### DIFF
--- a/lxqt-config-file-associations/applicationchooser.cpp
+++ b/lxqt-config-file-associations/applicationchooser.cpp
@@ -41,7 +41,7 @@
 
 Q_DECLARE_METATYPE(XdgDesktopFile*)
 
-ApplicationChooser::ApplicationChooser(const QString& type, int cat)
+ApplicationChooser::ApplicationChooser(const QString& type, int cat, QWidget *parent) : QDialog(parent)
 {
     widget.setupUi(this);
 

--- a/lxqt-config-file-associations/applicationchooser.h
+++ b/lxqt-config-file-associations/applicationchooser.h
@@ -43,7 +43,7 @@ public:
         fileManager
     };
 
-    ApplicationChooser(const QString& type, int cat = category::none);
+    ApplicationChooser(const QString& type, int cat = category::none, QWidget *parent = nullptr);
 
     virtual ~ApplicationChooser();
 

--- a/lxqt-config-file-associations/applicationchooser.ui
+++ b/lxqt-config-file-associations/applicationchooser.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Application Chooser</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QFrame" name="frame_2">

--- a/lxqt-config-file-associations/mimetypeviewer.cpp
+++ b/lxqt-config-file-associations/mimetypeviewer.cpp
@@ -430,7 +430,7 @@ void MimetypeViewer::chooseApplication()
 XdgDesktopFile* MimetypeViewer::chooseApp(const QString& type, int cat)
 {
     XdgDesktopFile *app = nullptr;
-    ApplicationChooser applicationChooser(type, cat);
+    ApplicationChooser applicationChooser(type, cat, this);
     int dialogCode = applicationChooser.exec();
     app = applicationChooser.DefaultApplication();
     if (app)


### PR DESCRIPTION
This ensures that the dialog is attached to the main window. Also mark it as modal.