### PR TITLE
Assign advanced settings to the parent window

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -238,7 +238,7 @@ void MonitorSettingsDialog::showSettingsDialog()
 
     LXQt::Settings settings(QString::fromLocal8Bit(configName));
 
-    SettingsDialog settingsDialog(tr("Advanced settings"), &settings, mConfig);
+    SettingsDialog settingsDialog(tr("Advanced settings"), &settings, mConfig, this);
     settingsDialog.exec();
 }
 


### PR DESCRIPTION
This ensures that the dialog is attached to the monitor settings window.