### PR TITLE
Added missing quotes to autostart *.yaml files

### DIFF
--- a/lxqt-config-input/translations/lxqt-config-touchpad-autostart.desktop.yaml
+++ b/lxqt-config-input/translations/lxqt-config-touchpad-autostart.desktop.yaml
@@ -1,1 +1,1 @@
-Desktop Entry/Name: Mouse and Touchpad Settings
+Desktop Entry/Name: "Mouse and Touchpad Settings"

--- a/lxqt-config-monitor/translations/lxqt-config-monitor-autostart.desktop.yaml
+++ b/lxqt-config-monitor/translations/lxqt-config-monitor-autostart.desktop.yaml
@@ -1,1 +1,1 @@
-Desktop Entry/Name: Monitor Settings
+Desktop Entry/Name: "Monitor Settings"


### PR DESCRIPTION
Looks like Weblate needs quotes - the translations are coming in like that:
https://github.com/lxqt/lxqt-config/pull/1153/files
while on weblate it's ok:
<img width="667" height="351" alt="immagine" src="https://github.com/user-attachments/assets/07d5a2c6-8eaf-4040-b71f-a89fdfa82c64" />

All our other `*.yaml` files use quotes too. It worked without testing locally though.