### PR TITLE
Restore margins to Default Applications page

### DIFF
--- a/lxqt-config-file-associations/mimetypeviewer.ui
+++ b/lxqt-config-file-associations/mimetypeviewer.ui
@@ -329,18 +329,6 @@
            <property name="spacing">
             <number>5</number>
            </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
            <item>
             <widget class="QGroupBox" name="browserGroupBox">
              <property name="title">


### PR DESCRIPTION
The rationale is that, after observing the GUI carefully, Associations → right column, has margins.

Default Applications had removed margins, therefore the groupboxes were touching the scrollbar (at least in Fusion.) I see no reason to remove the margins.