### PR TITLE
lxqt-config-appearance: Remove double margins for scrollarea pages

### DIFF
--- a/lxqt-config-appearance/gtkconfig.ui
+++ b/lxqt-config-appearance/gtkconfig.ui
@@ -32,6 +32,18 @@
        <property name="spacing">
         <number>10</number>
        </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QLabel" name="label">
          <property name="font">

--- a/lxqt-config-appearance/styleconfig.ui
+++ b/lxqt-config-appearance/styleconfig.ui
@@ -21,6 +21,18 @@
      </property>
      <widget class="QWidget" name="scrollAreaWidgetContents">
       <layout class="QFormLayout" name="formLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item row="0" column="0">
         <widget class="QLabel" name="label">
          <property name="font">


### PR DESCRIPTION
Previously the pages with scrollareas (Widget Style, GTK Config) had bigger encompassing margins due to the extra layouts. This also worked against needing the scrollareas.