### PR TITLE
Remove unnecessary headers

### DIFF
--- a/liblxqt-config-cursor/cfgfile.cpp
+++ b/liblxqt-config-cursor/cfgfile.cpp
@@ -7,6 +7,7 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #include "cfgfile.h"
 
 #include <QDir>

--- a/liblxqt-config-cursor/crtheme.cpp
+++ b/liblxqt-config-cursor/crtheme.cpp
@@ -19,7 +19,6 @@
 /*
  * additional code: Ketmar // Vampire Avalon (psyc://ketmar.no-ip.org/~Ketmar)
  */
-#include <QDebug>
 
 #include "crtheme.h"
 #include "xcr/xcrimg.h"

--- a/liblxqt-config-cursor/crtheme.h
+++ b/liblxqt-config-cursor/crtheme.h
@@ -23,9 +23,7 @@
 #define CRTHEME_H
 
 #include <QApplication>
-#include <QCursor>
 #include <QDir>
-#include <QFile>
 #include <QIcon>
 #include <QImage>
 #include <QString>

--- a/liblxqt-config-cursor/crtheme.h
+++ b/liblxqt-config-cursor/crtheme.h
@@ -24,10 +24,8 @@
 
 #include <QApplication>
 #include <QDir>
-#include <QIcon>
 #include <QImage>
 #include <QString>
-#include <QStringList>
 
 //#include <xcb/xcb.h>
 //#include <xcb/xproto.h>

--- a/liblxqt-config-cursor/itemdelegate.cpp
+++ b/liblxqt-config-cursor/itemdelegate.cpp
@@ -16,13 +16,14 @@
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02110-1301, USA.
  */
+
 /*
  * additional code: Ketmar // Vampire Avalon (psyc://ketmar.no-ip.org/~Ketmar)
  */
+
 #include "itemdelegate.h"
 #include "crtheme.h"
 
-#include <QApplication>
 #include <QModelIndex>
 #include <QPainter>
 
@@ -31,7 +32,6 @@
 namespace {
     const int decorationMargin = 8;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 ItemDelegate::ItemDelegate(QObject *parent) : QAbstractItemDelegate(parent)

--- a/liblxqt-config-cursor/main.cpp
+++ b/liblxqt-config-cursor/main.cpp
@@ -7,22 +7,13 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-//#include <QtCore>
-#include <QDebug>
 
-#include <XdgIcon>
-#include <LXQt/Settings>
 #include "main.h"
 #include "lxqttranslate.h"
 
+#include <XdgIcon>
 #include <LXQt/Application>
-#include <QFile>
-#include <QImage>
-#include <QString>
-#include <QStringList>
-#include <QTextCodec>
-#include <QTextStream>
-
+#include <LXQt/Settings>
 
 ///////////////////////////////////////////////////////////////////////////////
 int main (int argc, char *argv[])

--- a/liblxqt-config-cursor/main.h
+++ b/liblxqt-config-cursor/main.h
@@ -7,13 +7,12 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #ifndef MAIN_H
 #define MAIN_H
-
 
 #include "cfgfile.h"
 #include "crtheme.h"
 #include "selectwnd.h"
-
 
 #endif

--- a/liblxqt-config-cursor/previewwidget.cpp
+++ b/liblxqt-config-cursor/previewwidget.cpp
@@ -18,20 +18,16 @@
 /*
  * additional code: Ketmar // Vampire Avalon (psyc://ketmar.no-ip.org/~Ketmar)
  */
-#include <QDebug>
 
 #include <QPainter>
 #include <QMouseEvent>
+#include <QWindow>
 
 #include "previewwidget.h"
-
 #include "crtheme.h"
 
 #include <X11/Xlib.h>
 #include <X11/Xcursor/Xcursor.h>
-
-#include <QWindow>
-#include <QGuiApplication>
 
 #include <algorithm>
 

--- a/liblxqt-config-cursor/selectwnd.cpp
+++ b/liblxqt-config-cursor/selectwnd.cpp
@@ -10,17 +10,8 @@
 
 // 2014-04-10 modified by Hong Jen Yee (PCMan) for integration with lxqt-config-input
 
-#include <QDebug>
-
 #include "selectwnd.h"
 #include "ui_selectwnd.h"
-
-#include <QKeyEvent>
-#include <QMessageBox>
-#include <QTimer>
-#include <QWidget>
-#include <QPushButton>
-#include <QToolTip>
 
 #include "cfgfile.h"
 #include "crtheme.h"
@@ -31,14 +22,17 @@
 #include "xcrxcur.h"
 #include "xcrtheme.h"
 
-#include <LXQt/Settings>
-#include <XdgIcon>
+#include <QMessageBox>
+#include <QWidget>
+#include <QToolTip>
 #include <QTextStream>
 #include <QProcess>
+#include <QDebug>
+
+#include <LXQt/Settings>
+#include <XdgIcon>
 
 #include <X11/Xcursor/Xcursor.h>
-
-#include <QGuiApplication>
 
 const QString HOME_ICON_DIR(QDir::homePath() + QStringLiteral("/.icons"));
 

--- a/liblxqt-config-cursor/selectwnd.h
+++ b/liblxqt-config-cursor/selectwnd.h
@@ -13,7 +13,6 @@
 #ifndef SELECTWND_H
 #define SELECTWND_H
 
-#include <QObject>
 #include <QWidget>
 #include <QPersistentModelIndex>
 #include <lxqtglobals.h>

--- a/liblxqt-config-cursor/thememodel.h
+++ b/liblxqt-config-cursor/thememodel.h
@@ -19,6 +19,7 @@
 /*
  * additional code: Ketmar // Vampire Avalon (psyc://ketmar.no-ip.org/~Ketmar)
  */
+
 #ifndef THEMEMODEL_H
 #define THEMEMODEL_H
 

--- a/liblxqt-config-cursor/warninglabel.h
+++ b/liblxqt-config-cursor/warninglabel.h
@@ -30,7 +30,6 @@
 
 #include "ui_warninglabel.h"
 
-
 class WarningLabel : public QWidget, public Ui::WarningLabel
 {
     Q_OBJECT

--- a/liblxqt-config-cursor/xcr/xcrimg.cpp
+++ b/liblxqt-config-cursor/xcr/xcrimg.cpp
@@ -7,7 +7,6 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-#include <QDebug>
 
 #include "xcrimg.h"
 
@@ -15,7 +14,6 @@
 #include <QPaintEngine>
 #include <QStringList>
 #include <QStyle>
-#include <QTextStream>
 #include <QSettings>
 #include <QString>
 

--- a/liblxqt-config-cursor/xcr/xcrimg.h
+++ b/liblxqt-config-cursor/xcr/xcrimg.h
@@ -10,10 +10,10 @@
 #ifndef XCRIMG_H
 #define XCRIMG_H
 
-#include <QtCore>
+#include <QDir>
+#include <QFile>
 #include <QCursor>
 #include <QPixmap>
-
 
 class XCursorImage {
 public:

--- a/liblxqt-config-cursor/xcr/xcrtheme.cpp
+++ b/liblxqt-config-cursor/xcr/xcrtheme.cpp
@@ -7,18 +7,16 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-#include <QDebug>
-//#include <QtCore>
 
 #include "xcrtheme.h"
-
-#include <unistd.h>
+#include "xcrimg.h"
+#include "xcrxcur.h"
 
 #include <QStringList>
 #include <QTextStream>
+#include <QDebug>
 
-#include "xcrimg.h"
-#include "xcrxcur.h"
+#include <unistd.h>
 
 /*
  0   standard arrow

--- a/liblxqt-config-cursor/xcr/xcrtheme.h
+++ b/liblxqt-config-cursor/xcr/xcrtheme.h
@@ -10,12 +10,8 @@
 #ifndef XCRTHEME_H
 #define XCRTHEME_H
 
-#include <QtCore>
-#include <QCursor>
-#include <QPixmap>
-
 #include "xcrimg.h"
-
+#include <QProcess>
 
 class XCursorTheme {
 public:
@@ -86,12 +82,10 @@ protected:
   QList<XCursorImages *> mList;
 };
 
-
 bool removeXCursorTheme (const QDir &thDir, const QString &name);
 bool removeXCursorTheme (const QString &name);
 bool removeXCursorTheme (const QDir &thDir);
 
 bool packXCursorTheme (const QString &destFName, const QDir &thDir, const QString &thName, bool removeTheme=false);
-
 
 #endif

--- a/liblxqt-config-cursor/xcr/xcrthemefx.cpp
+++ b/liblxqt-config-cursor/xcr/xcrthemefx.cpp
@@ -7,24 +7,20 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-#include <QDebug>
-//#include <QtCore>
 
 #include "xcrthemefx.h"
-
-#include <unistd.h>
-#include <zlib.h>
-
-#include <QSet>
-#include <QStringList>
-#include <QTextStream>
-
-#include <algorithm>
-
 #include "xcrimg.h"
 #include "xcrxcur.h"
 #include "xcrtheme.h"
 
+#include <QSet>
+#include <QStringList>
+#include <QTextStream>
+#include <QDebug>
+
+#include <unistd.h>
+#include <zlib.h>
+#include <algorithm>
 
 static const char *curShapeName[] = {
   "standard arrow",

--- a/liblxqt-config-cursor/xcr/xcrthemefx.h
+++ b/liblxqt-config-cursor/xcr/xcrthemefx.h
@@ -10,7 +10,7 @@
 #ifndef XCRTHEMEFX_H
 #define XCRTHEMEFX_H
 
-#include <QtCore>
+#include <QString>
 #include <QCursor>
 #include <QPixmap>
 

--- a/liblxqt-config-cursor/xcr/xcrthemexp.cpp
+++ b/liblxqt-config-cursor/xcr/xcrthemexp.cpp
@@ -7,25 +7,21 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-#include <QDebug>
-//#include <QtCore>
 
 #include "xcrthemexp.h"
-
-#include <unistd.h>
-#include <zlib.h>
-
-#include <QSet>
-#include <QStringList>
-#include <QTextStream>
-
-#include <algorithm>
-
 #include "xcrimg.h"
 #include "xcrxcur.h"
 #include "xcrtheme.h"
 #include "xcrthemefx.h"
 
+#include <QDebug>
+#include <QSet>
+#include <QStringList>
+#include <QTextStream>
+
+#include <unistd.h>
+#include <zlib.h>
+#include <algorithm>
 
 static const char *curShapeName[] = {
   "Arrow",

--- a/liblxqt-config-cursor/xcr/xcrthemexp.h
+++ b/liblxqt-config-cursor/xcr/xcrthemexp.h
@@ -7,17 +7,18 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #ifndef XCRTHEMEXP_H
 #define XCRTHEMEXP_H
 
-#include <QtCore>
+#include <QDir>
+#include <QString>
 #include <QCursor>
 #include <QPixmap>
 
 #include "xcrimg.h"
 #include "xcrtheme.h"
 #include "xcrthemefx.h"
-
 
 class XCursorThemeXP : public XCursorTheme {
 public:

--- a/liblxqt-config-cursor/xcr/xcrxcur.cpp
+++ b/liblxqt-config-cursor/xcr/xcrxcur.cpp
@@ -7,21 +7,12 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-#include <QDebug>
-//#include <QtCore>
 
 #include "xcrxcur.h"
-
-#include <QApplication>
-#include <QStringList>
-#include <QStyle>
-#include <QTextStream>
-
 
 #include <X11/Xlib.h>
 #include <X11/Xcursor/Xcursor.h>
 #include <X11/extensions/Xfixes.h>
-
 
 /*
 static QImage autoCropImage (const QImage &image) {

--- a/liblxqt-config-cursor/xcr/xcrxcur.h
+++ b/liblxqt-config-cursor/xcr/xcrxcur.h
@@ -10,12 +10,12 @@
 #ifndef XCRXCUR_H
 #define XCRXCUR_H
 
-#include <QtCore>
+#include <QDir>
+#include <QString>
 #include <QCursor>
 #include <QPixmap>
 
 #include "xcrimg.h"
-
 
 class XCursorImageXCur : public XCursorImage {
 public:

--- a/lxqt-config-appearance/colorLabel.h
+++ b/lxqt-config-appearance/colorLabel.h
@@ -28,7 +28,6 @@
 
 #include <QLabel>
 #include <QWidget>
-#include <Qt>
 
 class ColorLabel : public QLabel {
     Q_OBJECT

--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -24,6 +24,7 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include "configothertoolkits.h"
+
 #include <QFile>
 #include <QTextStream>
 #include <QStandardPaths>
@@ -36,7 +37,6 @@
 #include <QMessageBox>
 #include <QProcess>
 #include <QGuiApplication>
-#include <QDebug>
 
 #include <sys/types.h>
 #include <signal.h>

--- a/lxqt-config-appearance/fontconfigfile.cpp
+++ b/lxqt-config-appearance/fontconfigfile.cpp
@@ -23,13 +23,10 @@
 #include <QByteArray>
 #include <QFile>
 #include <QDir>
-#include <QDesktopServices>
-#include <QStringBuilder>
 #include <QDomDocument>
 #include <QFont>
 #include <QFontInfo>
 #include <QTimer>
-#include <QDebug>
 #include <QStandardPaths>
 
 FontConfigFile::FontConfigFile(QObject* parent):

--- a/lxqt-config-appearance/fontsconfig.cpp
+++ b/lxqt-config-appearance/fontsconfig.cpp
@@ -27,17 +27,9 @@
 
 #include "fontsconfig.h"
 #include "ui_fontsconfig.h"
-#include <QTreeWidget>
-#include <QDebug>
 #include <QSettings>
 #include <QFont>
 #include <QFontInfo>
-#include <QFile>
-#include <QDir>
-#include <QDesktopServices>
-#include <QTextStream>
-#include <QStringBuilder>
-#include <QDomDocument>
 
 static const char* subpixelNames[] = {"none", "rgb", "bgr", "vrgb", "vbgr"};
 static const char* hintStyleNames[] = {"hintnone", "hintslight", "hintmedium", "hintfull"};

--- a/lxqt-config-appearance/fontsconfig.h
+++ b/lxqt-config-appearance/fontsconfig.h
@@ -28,10 +28,10 @@
 #ifndef FONTSCONFIG_H
 #define FONTSCONFIG_H
 
+#include "fontconfigfile.h"
+#include <LXQt/Settings>
 #include <QWidget>
 #include <QFont>
-#include <LXQt/Settings>
-#include "fontconfigfile.h"
 
 class QTreeWidgetItem;
 class QSettings;

--- a/lxqt-config-appearance/gtkconfig.cpp
+++ b/lxqt-config-appearance/gtkconfig.cpp
@@ -25,7 +25,6 @@
 
 #include "gtkconfig.h"
 #include "ui_gtkconfig.h"
-#include <QDebug>
 
 GTKConfig::GTKConfig(LXQt::Settings *configAppearanceSettings, ConfigOtherToolKits *configOtherToolKits, QWidget* parent) :
     QWidget(parent),

--- a/lxqt-config-appearance/gtkconfig.h
+++ b/lxqt-config-appearance/gtkconfig.h
@@ -26,9 +26,9 @@
 #ifndef GTKCONFIG_H
 #define GTKCONFIG_H
 
-#include <QWidget>
 #include "ui_gtkconfig.h"
 #include "configothertoolkits.h"
+#include <QWidget>
 
 namespace Ui {
     class GTKConfig;

--- a/lxqt-config-appearance/iconthemeconfig.cpp
+++ b/lxqt-config-appearance/iconthemeconfig.cpp
@@ -29,7 +29,6 @@
 
 #include <LXQt/Settings>
 #include <QStringList>
-#include <QStringBuilder>
 #include <QIcon>
 
 IconThemeConfig::IconThemeConfig(LXQt::Settings* settings, QWidget* parent):

--- a/lxqt-config-appearance/lxqtthemeconfig.h
+++ b/lxqt-config-appearance/lxqtthemeconfig.h
@@ -28,9 +28,9 @@
 #ifndef LXQTTHEMECONFIG_H
 #define LXQTTHEMECONFIG_H
 
-#include <QWidget>
-#include <LXQt/Settings>
 #include "styleconfig.h"
+#include <LXQt/Settings>
+#include <QWidget>
 
 class QTreeWidgetItem;
 

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -25,14 +25,6 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <LXQt/SingleApplication>
-
-#include <LXQt/Settings>
-#include <LXQt/ConfigDialog>
-#include <QCommandLineParser>
-#include <QMessageBox>
-#include <QGuiApplication>
-
 #include "iconthemeconfig.h"
 #include "lxqtthemeconfig.h"
 #include "styleconfig.h"
@@ -41,6 +33,12 @@
 #include "gtkconfig.h"
 
 #include "../liblxqt-config-cursor/selectwnd.h"
+
+#include <LXQt/SingleApplication>
+#include <LXQt/Settings>
+#include <LXQt/ConfigDialog>
+
+#include <QCommandLineParser>
 
 int main (int argc, char **argv)
 {

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -30,7 +30,6 @@
 #include "ui_palettes.h"
 
 #include <QStyleFactory>
-#include <QToolBar>
 #include <QSettings>
 #include <QMetaObject>
 #include <QMetaProperty>

--- a/lxqt-config-appearance/styleconfig.cpp
+++ b/lxqt-config-appearance/styleconfig.cpp
@@ -28,7 +28,7 @@
 #include "styleconfig.h"
 #include "ui_styleconfig.h"
 #include "ui_palettes.h"
-#include <QDebug>
+
 #include <QStyleFactory>
 #include <QToolBar>
 #include <QSettings>

--- a/lxqt-config-appearance/styleconfig.h
+++ b/lxqt-config-appearance/styleconfig.h
@@ -28,9 +28,9 @@
 #ifndef STYLECONFIG_H
 #define STYLECONFIG_H
 
-#include <QWidget>
-#include <LXQt/Settings>
 #include "configothertoolkits.h"
+#include <LXQt/Settings>
+#include <QWidget>
 
 class QSettings;
 

--- a/lxqt-config-brightness/brightnesssettings.cpp
+++ b/lxqt-config-brightness/brightnesssettings.cpp
@@ -18,6 +18,7 @@
 
 #include "brightnesssettings.h"
 #include "outputwidget.h"
+
 #include <QMessageBox>
 #include <QPushButton>
 

--- a/lxqt-config-brightness/main.cpp
+++ b/lxqt-config-brightness/main.cpp
@@ -18,13 +18,14 @@
 
 #include "xrandrbrightness.h"
 #include "brightnesswatcher.h"
+#include "brightnesssettings.h"
+
+#include <LXQt/SingleApplication>
 
 #include <QDebug>
 #include <QTimer>
-#include <LXQt/SingleApplication>
 #include <QCommandLineParser>
 #include <QMessageBox>
-#include "brightnesssettings.h"
 
 #include <iostream>
 #include <cmath>

--- a/lxqt-config-brightness/monitorinfo.h
+++ b/lxqt-config-brightness/monitorinfo.h
@@ -21,7 +21,6 @@
 
 #include <QString>
 
-
 /** This class represents backlight and brightness values of screen.
  * If backlight is supported, backlight power of screen can be changed.
  * Brightness represents color saturation.

--- a/lxqt-config-brightness/outputwidget.h
+++ b/lxqt-config-brightness/outputwidget.h
@@ -19,10 +19,10 @@
 #ifndef __OUTPUT_WIDGET_H__
 #define __OUTPUT_WIDGET_H__
 
-#include <QGroupBox>
-#include <QMouseEvent>
 #include "monitorinfo.h"
 #include "ui_outputwidget.h"
+
+#include <QMouseEvent>
 
 class OutputWidget: public QWidget
 {

--- a/lxqt-config-brightness/xrandrbrightness.cpp
+++ b/lxqt-config-brightness/xrandrbrightness.cpp
@@ -18,13 +18,12 @@
  *
  */
 
+#include "xrandrbrightness.h"
 
 #include <QGuiApplication>
 #include <QDebug>
 
 #include <algorithm>
-
-#include "xrandrbrightness.h"
 
 XRandrBrightness::XRandrBrightness()
 {

--- a/lxqt-config-brightness/xrandrbrightness.h
+++ b/lxqt-config-brightness/xrandrbrightness.h
@@ -21,13 +21,13 @@
 #ifndef XRANDRBRIGHTNESS_H
 #define XRANDRBRIGHTNESS_H
 
+#include "monitorinfo.h"
+
 #include <xcb/xcb.h>
 #include <xcb/randr.h>
 
 #include <QScopedPointer>
 #include <QList>
-
-#include "monitorinfo.h"
 
 template <typename T> using ScopedCPointer = QScopedPointer<T, QScopedPointerPodDeleter>;
 

--- a/lxqt-config-file-associations/applicationchooser.cpp
+++ b/lxqt-config-file-associations/applicationchooser.cpp
@@ -23,11 +23,11 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+#include "applicationchooser.h"
+
 #include <QDialogButtonBox>
 #include <QPushButton>
-#include <QSettings>
 #include <QString>
-#include <QDebug>
 #include <QMimeDatabase>
 #include <QTimer>
 
@@ -36,8 +36,6 @@
 #include <XdgDefaultApps>
 
 #include <algorithm>
-
-#include "applicationchooser.h"
 
 Q_DECLARE_METATYPE(XdgDesktopFile*)
 
@@ -95,8 +93,6 @@ int ApplicationChooser::exec()
 
     return QDialog::exec();
 }
-
-
 
 bool lessThan(XdgDesktopFile* a, XdgDesktopFile* b)
 {

--- a/lxqt-config-file-associations/main.cpp
+++ b/lxqt-config-file-associations/main.cpp
@@ -23,21 +23,16 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+#include "mimetypeviewer.h"
+
 #include <LXQt/SingleApplication>
-
-#include <QDebug>
-#include <QString>
-#include <QStringList>
-#include <QFile>
-#include <QIODevice>
-#include <QSettings>
-#include <QVariant>
-#include <QCommandLineParser>
-
 #include <LXQt/Settings>
 #include <XdgDesktopFile>
-#include "mimetypeviewer.h"
 #include <XdgDirs>
+
+#include <QString>
+#include <QSettings>
+#include <QCommandLineParser>
 
 int main (int argc, char **argv)
 {

--- a/lxqt-config-file-associations/mimetypedata.cpp
+++ b/lxqt-config-file-associations/mimetypedata.cpp
@@ -25,13 +25,11 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-
 #include "mimetypedata.h"
 
 MimeTypeData::MimeTypeData()
 {
 }
-
 
 MimeTypeData::MimeTypeData(const XdgMimeType& mime)
 {
@@ -39,7 +37,6 @@ MimeTypeData::MimeTypeData(const XdgMimeType& mime)
     mPatterns = mime.globPatterns().join(QStringLiteral(" "));
     mComment = mime.comment();
 }
-
 
 bool MimeTypeData::matches(const QString &filter) const
 {

--- a/lxqt-config-file-associations/mimetypedata.h
+++ b/lxqt-config-file-associations/mimetypedata.h
@@ -25,13 +25,11 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-
 #ifndef MIMETYPEDATA_H
 #define MIMETYPEDATA_H
 
 #include <XdgMimeType>
 #include <QMetaType>
-
 
 class MimeTypeData {
 public:

--- a/lxqt-config-file-associations/mimetypeitemmodel.cpp
+++ b/lxqt-config-file-associations/mimetypeitemmodel.cpp
@@ -7,11 +7,9 @@
 * the AUTHORS file for copyright and authorship information.
 */
 
-#include <QObject>
-#include <QDebug>
-
 #include "mimetypeitemmodel.h"
 #include <XdgMime>
+#include <QObject>
 
 /*
  * Implementation note:
@@ -28,7 +26,6 @@
  *
  * QModelIndexes for mediatypes have no parents, and QModelIndexes for subtypes have no children.
  */
-
 
 MimetypeItemModel::MimetypeItemModel(QObject *parent) :
 QAbstractItemModel(parent)

--- a/lxqt-config-file-associations/mimetypeviewer.cpp
+++ b/lxqt-config-file-associations/mimetypeviewer.cpp
@@ -24,15 +24,12 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <QListWidgetItem>
-#include <QDebug>
+#include "mimetypeviewer.h"
+#include "ui_mimetypeviewer.h"
+
 #include <QIcon>
-#include <QPixmap>
-#include <QListWidget>
 #include <QMimeDatabase>
 #include <QMimeType>
-#include <QDateTime>
-#include <QFileInfo>
 
 #include <XdgDesktopFile>
 #include <XdgDefaultApps>
@@ -40,10 +37,6 @@
 #include <XdgDirs>
 
 #include <algorithm>
-
-#include "mimetypeviewer.h"
-#include "ui_mimetypeviewer.h"
-
 
 enum ItemTypeEntries {
     GroupType = 1001,

--- a/lxqt-config-file-associations/mimetypeviewer.h
+++ b/lxqt-config-file-associations/mimetypeviewer.h
@@ -27,15 +27,15 @@
 #ifndef _MIMETYPEVIEWER_H
 #define	_MIMETYPEVIEWER_H
 
-#include <QDialog>
-#include <QStringList>
-#include <QTemporaryFile>
-
-#include <XdgMimeType>
-
 #include "mimetypedata.h"
 #include "ui_mimetypeviewer.h"
 #include "applicationchooser.h"
+
+#include <XdgMimeType>
+
+#include <QDialog>
+#include <QStringList>
+#include <QTemporaryFile>
 
 class QSettings;
 

--- a/lxqt-config-input/keyboardconfig.cpp
+++ b/lxqt-config-input/keyboardconfig.cpp
@@ -18,13 +18,8 @@
 
 
 #include "keyboardconfig.h"
-#include <string.h>
-#include <math.h>
-#include <stdlib.h>
+
 #include <LXQt/Settings>
-#include <QDir>
-#include <QFile>
-#include <QStringBuilder>
 
 // FIXME: how to support XCB or Wayland?
 #include <X11/Xlib.h>

--- a/lxqt-config-input/keyboardconfig.h
+++ b/lxqt-config-input/keyboardconfig.h
@@ -20,8 +20,9 @@
 #ifndef KEYBOARDCONFIG_H
 #define KEYBOARDCONFIG_H
 
-#include <QDialog>
 #include "ui_keyboardconfig.h"
+
+#include <QDialog>
 
 namespace LXQt {
   class Settings;

--- a/lxqt-config-input/keyboardlayoutconfig.cpp
+++ b/lxqt-config-input/keyboardlayoutconfig.cpp
@@ -19,12 +19,13 @@
  */
 
 #include "keyboardlayoutconfig.h"
+#include "selectkeyboardlayoutdialog.h"
+
+#include <LXQt/Settings>
+
 #include <QProcess>
 #include <QFile>
-#include <QHash>
 #include <QDebug>
-#include "selectkeyboardlayoutdialog.h"
-#include <LXQt/Settings>
 
 KeyboardLayoutConfig::KeyboardLayoutConfig(LXQt::Settings* _settings, QWidget* parent):
   QWidget(parent),

--- a/lxqt-config-input/keyboardlayoutconfig.h
+++ b/lxqt-config-input/keyboardlayoutconfig.h
@@ -21,7 +21,6 @@
 #ifndef KEYBOARDLAYOUTCONFIG_H
 #define KEYBOARDLAYOUTCONFIG_H
 
-#include <QtCore/QtGlobal>
 #ifdef Q_OS_LINUX
 #define XKBD_BASELIST_PATH "/usr/share/X11/xkb/rules/base.lst"
 #elif defined(Q_OS_FREEBSD)
@@ -32,10 +31,11 @@
 #define XKBD_BASELIST_PATH "/usr/local/share/X11/xkb/rules/base.lst"
 #endif
 
-#include <QWidget>
 #include "keyboardlayoutinfo.h"
-#include <QMap>
 #include "ui_keyboardlayoutconfig.h"
+
+#include <QWidget>
+#include <QMap>
 
 namespace LXQt {
   class Settings;

--- a/lxqt-config-input/lxqt-config-input.cpp
+++ b/lxqt-config-input/lxqt-config-input.cpp
@@ -18,12 +18,6 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <LXQt/SingleApplication>
-#include <LXQt/ConfigDialog>
-#include <LXQt/ConfigDialogCmdLineOptions>
-#include <LXQt/Settings>
-#include <QCommandLineParser>
-#include <QMessageBox>
 #include "mouseconfig.h"
 #include "keyboardconfig.h"
 #include "../liblxqt-config-cursor/selectwnd.h"
@@ -34,6 +28,13 @@
 #include "touchpadconfig.h"
 #include "touchpaddevice.h"
 #endif
+
+#include <LXQt/SingleApplication>
+#include <LXQt/ConfigDialog>
+#include <LXQt/ConfigDialogCmdLineOptions>
+#include <LXQt/Settings>
+
+#include <QCommandLineParser>
 
 int main(int argc, char** argv) {
     LXQt::SingleApplication app(argc, argv);

--- a/lxqt-config-input/lxqt-config-input.h
+++ b/lxqt-config-input/lxqt-config-input.h
@@ -11,5 +11,4 @@
 #define LXQT_CONFIG_INPUT_H
 
 
-
 #endif // LXQT_CONFIG_INPUT_H

--- a/lxqt-config-input/mouseconfig.cpp
+++ b/lxqt-config-input/mouseconfig.cpp
@@ -18,14 +18,8 @@
 
 
 #include "mouseconfig.h"
-#include <string.h>
-#include <math.h>
-#include <stdlib.h>
+
 #include <LXQt/Settings>
-#include <QDir>
-#include <QFile>
-#include <QStringBuilder>
-#include <QDebug>
 
 // FIXME: how to support XCB or Wayland?
 #include <X11/Xlib.h>

--- a/lxqt-config-input/mouseconfig.h
+++ b/lxqt-config-input/mouseconfig.h
@@ -20,8 +20,9 @@
 #ifndef MOUSECONFIG_H
 #define MOUSECONFIG_H
 
-#include <QWidget>
 #include "ui_mouseconfig.h"
+
+#include <QWidget>
 
 namespace LXQt {
   class Settings;

--- a/lxqt-config-input/selectkeyboardlayoutdialog.cpp
+++ b/lxqt-config-input/selectkeyboardlayoutdialog.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "selectkeyboardlayoutdialog.h"
-#include <QDebug>
 
 SelectKeyboardLayoutDialog::SelectKeyboardLayoutDialog(QMap< QString, KeyboardLayoutInfo>& knownLayouts, QWidget* parent):
   QDialog(parent),

--- a/lxqt-config-input/selectkeyboardlayoutdialog.h
+++ b/lxqt-config-input/selectkeyboardlayoutdialog.h
@@ -21,9 +21,10 @@
 #ifndef SELECTKEYBOARDLAYOUTDIALOG_H
 #define SELECTKEYBOARDLAYOUTDIALOG_H
 
-#include <QDialog>
 #include "ui_selectkeyboardlayoutdialog.h"
 #include "keyboardlayoutinfo.h"
+
+#include <QDialog>
 
 class SelectKeyboardLayoutDialog : public QDialog {
   Q_OBJECT

--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -19,17 +19,14 @@
 #include "touchpadconfig.h"
 #include "touchpaddevice.h"
 
-#include <cmath>
-
-#include <QDebug>
 #include <QFile>
 #include <QString>
-#include <QUrl>
 
 #include <XdgDirs>
-
 #include <LXQt/AutostartEntry>
 #include <LXQt/Settings>
+
+#include <cmath>
 
 using namespace Qt::Literals::StringLiterals;
 

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -19,8 +19,9 @@
 #ifndef TOUCHPADCONFIG_H
 #define TOUCHPADCONFIG_H
 
-#include <QWidget>
 #include "ui_touchpadconfig.h"
+
+#include <QWidget>
 
 namespace LXQt
 {

--- a/lxqt-config-input/touchpaddevice.cpp
+++ b/lxqt-config-input/touchpaddevice.cpp
@@ -18,15 +18,17 @@
 
 #include "touchpaddevice.h"
 
-#include <cmath>
 #include <QDebug>
 #include <QGuiApplication>
 #include <QUrl>
+
 #include <libudev.h>
 #include <LXQt/Settings>
 #include <X11/Xatom.h>
 #include <X11/extensions/XInput2.h>
 #include <libinput-properties.h>
+
+#include <cmath>
 
 static QList<QVariant> xi2_get_device_property(int deviceid, const char* prop)
 {

--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -30,13 +30,9 @@
 #include "localeconfig.h"
 #include "ui_localeconfig.h"
 
-#include <QApplication>
 #include <QComboBox>
-#include <QFile>
-#include <QDebug>
 #include <QLocale>
 #include <QStandardPaths>
-#include <QTextStream>
 #include <QDateTime>
 #include <QMessageBox>
 

--- a/lxqt-config-locale/localeconfig.h
+++ b/lxqt-config-locale/localeconfig.h
@@ -30,14 +30,12 @@
 #include <QWidget>
 #include <LXQt/Settings>
 
-class QTreeWidgetItem;
-class QSettings;
-
-
 namespace Ui {
     class LocaleConfig;
 }
 
+class QTreeWidgetItem;
+class QSettings;
 class QComboBox;
 class QMessageWidget;
 

--- a/lxqt-config-locale/main.cpp
+++ b/lxqt-config-locale/main.cpp
@@ -23,12 +23,13 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <LXQt/SingleApplication>
+#include "localeconfig.h"
 
+#include <LXQt/SingleApplication>
 #include <LXQt/Settings>
 #include <LXQt/ConfigDialog>
+
 #include <QCommandLineParser>
-#include "localeconfig.h"
 
 int main (int argc, char **argv)
 {

--- a/lxqt-config-monitor/fastmenu.cpp
+++ b/lxqt-config-monitor/fastmenu.cpp
@@ -22,6 +22,7 @@
 
 #include <QComboBox>
 #include <QPoint>
+
 #include <KScreen/Output>
 #include <KScreen/Mode>
 #include <KScreen/SetConfigOperation>

--- a/lxqt-config-monitor/fastmenu.h
+++ b/lxqt-config-monitor/fastmenu.h
@@ -20,14 +20,8 @@
 #define _FASTMENU_H_
 
 #include "ui_fastmenu.h"
-
 #include <QGroupBox>
-#include <QStringList>
-#include <QHash>
-#include <QList>
 #include <KScreen/Config>
-
-
 
 class FastMenu : public QGroupBox
 {

--- a/lxqt-config-monitor/loadsettings.cpp
+++ b/lxqt-config-monitor/loadsettings.cpp
@@ -16,9 +16,6 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-
-
-
 #include "loadsettings.h"
 #include "kscreenutils.h"
 #include <KScreen/Output>
@@ -30,7 +27,6 @@
 #include <LXQt/Notification>
 #include <KScreen/EDID>
 #include <QCoreApplication>
-
 
 LoadSettings::LoadSettings(QObject *parent):QObject(parent)
 {

--- a/lxqt-config-monitor/loadsettings.h
+++ b/lxqt-config-monitor/loadsettings.h
@@ -19,11 +19,11 @@
 #ifndef __LOADSETTINGS_H__
 #define __LOADSETTINGS_H__
 
+#include "monitor.h"
 
 #include <KScreen/GetConfigOperation>
 #include <KScreen/SetConfigOperation>
 #include <LXQt/Notification>
-#include "monitor.h"
 
 class LoadSettings : public QObject
 {

--- a/lxqt-config-monitor/main.cpp
+++ b/lxqt-config-monitor/main.cpp
@@ -16,16 +16,14 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "monitorsettingsdialog.h"
+#include "loadsettings.h"
+
+#include <QCommandLineParser>
+
 #include <LXQt/SingleApplication>
 #include <LXQt/ConfigDialog>
 #include <LXQt/Settings>
-#include <QDebug>
-#include <QProcess>
-#include <QStandardPaths>
-#include <QCommandLineParser>
-#include "monitorsettingsdialog.h"
-#include <QCoreApplication>
-#include "loadsettings.h"
 
 int main(int argc, char** argv)
 {

--- a/lxqt-config-monitor/managesavedsettings.cpp
+++ b/lxqt-config-monitor/managesavedsettings.cpp
@@ -21,10 +21,9 @@
 #include "loadsettings.h"
 #include "configure.h"
 #include "monitor.h"
-#include <QDebug>
+
 #include <QInputDialog>
 #include <QMessageBox>
-#include <QDateTime>
 
 Q_DECLARE_METATYPE(MonitorSavedSettings)
 

--- a/lxqt-config-monitor/managesavedsettings.h
+++ b/lxqt-config-monitor/managesavedsettings.h
@@ -22,6 +22,7 @@
 
 #include "ui_managesavedsettings.h"
 #include "monitor.h"
+
 #include <LXQt/Settings>
 #include <KScreen/Output>
 #include <KScreen/EDID>

--- a/lxqt-config-monitor/monitorpicture.cpp
+++ b/lxqt-config-monitor/monitorpicture.cpp
@@ -17,6 +17,9 @@
  */
 
 #include "monitorpicture.h"
+#include "configure.h"
+
+#include <KScreen/Mode>
 
 #include <QFont>
 #include <QFontMetrics>
@@ -24,15 +27,12 @@
 #include <QDebug>
 #include <QVector2D>
 #include <QRectF>
-#include <KScreen/Mode>
 #include <QScrollBar>
 #include <QResizeEvent>
 #include <QTransform>
 
 #include <cmath>
 #include <algorithm>
-
-#include "configure.h"
 
 // Gets size from string rate. String rate format is "widthxheight". Example: 800x600
 static QSize sizeFromString(QString str)

--- a/lxqt-config-monitor/monitorpicture.h
+++ b/lxqt-config-monitor/monitorpicture.h
@@ -19,14 +19,15 @@
 #ifndef _MONITORPICTURE_H_
 #define _MONITORPICTURE_H_
 
+#include "monitor.h"
+#include "ui_monitorpicture.h"
+#include "monitorwidget.h"
+
 #include <QGraphicsView>
 #include <QGraphicsRectItem>
 #include <QGraphicsTextItem>
 #include <QSvgRenderer>
 #include <QGraphicsSvgItem>
-#include "monitor.h"
-#include "ui_monitorpicture.h"
-#include "monitorwidget.h"
 
 class MonitorPicture;
 

--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -29,20 +29,17 @@
 
 #include <KScreen/Output>
 #include <KScreen/Mode>
-#include <QJsonObject>
-#include <QJsonArray>
 #include <LXQt/Settings>
-#include <QJsonDocument>
 #include <KScreen/EDID>
+
 #include <QFile>
-#include <QDir>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QDateTime>
 #include <QDebug>
 #include <QString>
-#include <lxqtautostartentry.h>
 
+#include <lxqtautostartentry.h>
 #include <XdgDirs>
 
 using namespace Qt::Literals::StringLiterals;

--- a/lxqt-config-monitor/monitorsettingsdialog.h
+++ b/lxqt-config-monitor/monitorsettingsdialog.h
@@ -24,7 +24,7 @@
 #include "timeoutdialog.h"
 
 #include <QDialog>
-#include <QTimer>
+
 #include <KScreen/GetConfigOperation>
 #include <KScreen/SetConfigOperation>
 

--- a/lxqt-config-monitor/monitorwidget.cpp
+++ b/lxqt-config-monitor/monitorwidget.cpp
@@ -20,8 +20,7 @@
 #include "monitorwidget.h"
 
 #include <QComboBox>
-#include <QStringBuilder>
-#include <QDialogButtonBox>
+
 #include <KScreen/Mode>
 #include <KScreen/EDID>
 

--- a/lxqt-config-monitor/monitorwidget.h
+++ b/lxqt-config-monitor/monitorwidget.h
@@ -23,9 +23,7 @@
 #include "ui_monitorwidget.h"
 
 #include <QGroupBox>
-#include <QStringList>
-#include <QHash>
-#include <QList>
+
 #include <KScreen/Config>
 #include <KScreen/Output>
 

--- a/lxqt-config-monitor/savesettings.cpp
+++ b/lxqt-config-monitor/savesettings.cpp
@@ -16,12 +16,13 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <QJsonArray>
-#include <QJsonObject>
 #include "savesettings.h"
 #include "configure.h"
-#include <QDebug>
+
+#include <QJsonArray>
 #include <QJsonDocument>
+#include <QJsonObject>
+#include <QDebug>
 #include <QProcess>
 #include <QInputDialog>
 

--- a/lxqt-config-monitor/settingsdialog.cpp
+++ b/lxqt-config-monitor/settingsdialog.cpp
@@ -18,6 +18,7 @@
 
 #include "settingsdialog.h"
 #include "managesavedsettings.h"
+
 #include <KScreen/Output>
 
 SettingsDialog::SettingsDialog(const QString &title, LXQt::Settings *settings, KScreen::ConfigPtr config, QWidget *parent)

--- a/lxqt-config-monitor/settingsdialog.h
+++ b/lxqt-config-monitor/settingsdialog.h
@@ -24,7 +24,6 @@
 #include <KScreen/GetConfigOperation>
 #include <KScreen/SetConfigOperation>
 
-
 class SettingsDialog : public LXQt::ConfigDialog
 {
     Q_OBJECT

--- a/lxqt-config-monitor/timeoutdialog.cpp
+++ b/lxqt-config-monitor/timeoutdialog.cpp
@@ -20,10 +20,10 @@
 
 #define TIMER_DURATION 10
 
+#include "timeoutdialog.h"
+
 #include <QIcon>
 #include <QStyle>
-
-#include "timeoutdialog.h"
 
 TimeoutDialog::TimeoutDialog(QWidget* parent, Qt::WindowFlags f) :
     QDialog(parent, f)

--- a/lxqt-config-monitor/timeoutdialog.h
+++ b/lxqt-config-monitor/timeoutdialog.h
@@ -21,6 +21,7 @@
 #define TIMEOUTDIALOG_H
 
 #include "ui_timeoutdialog.h"
+
 #include <QDialog>
 #include <QTimer>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,11 +24,12 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <LXQt/SingleApplication>
-#include <QSettings>
 #include "mainwindow.h"
-#include "QCommandLineParser"
 
+#include <LXQt/SingleApplication>
+
+#include <QCommandLineParser>
+#include <QSettings>
 
 int main(int argc, char **argv)
 {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -24,12 +24,12 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <QDirIterator>
-#include <QLineEdit>
-#include <QTimer>
-
 #include "mainwindow.h"
-#include <QtDebug>
+#include "qcategorizedview.h"
+#include "qcategorydrawer.h"
+#include "qcategorizedsortfilterproxymodel.h"
+
+#include <QTimer>
 #include <QMessageBox>
 #include <QStyledItemDelegate>
 #include <QShortcut>
@@ -39,10 +39,6 @@
 #include <XdgIcon>
 #include <XdgMenu>
 #include <XmlHelper>
-
-#include "qcategorizedview.h"
-#include "qcategorydrawer.h"
-#include "qcategorizedsortfilterproxymodel.h"
 
 #include <algorithm>
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,8 +27,6 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-
-
 #include "ui_mainwindow.h"
 #include <QtXml/QDomElement>
 

--- a/src/qcategorizedview/qcategorizedsortfilterproxymodel.cpp
+++ b/src/qcategorizedview/qcategorizedsortfilterproxymodel.cpp
@@ -24,10 +24,6 @@
 
 #include <climits>
 
-#include <QItemSelection>
-#include <QStringList>
-#include <QSize>
-
 //#include <kstringhandler.h>
 
 int naturalCompare(const QString &_a, const QString &_b, Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive)

--- a/src/qcategorizedview/qcategorizedsortfilterproxymodel.h
+++ b/src/qcategorizedview/qcategorizedsortfilterproxymodel.h
@@ -31,7 +31,6 @@
 
 class QItemSelection;
 
-
 /**
   * This class lets you categorize a view. It is meant to be used along with
   * QCategorizedView class.

--- a/src/qcategorizedview/qcategorizedview.cpp
+++ b/src/qcategorizedview/qcategorizedview.cpp
@@ -32,18 +32,14 @@
 
 #include "qcategorizedview.h"
 #include "qcategorizedview_p.h"
-
-#include <cmath> // trunc on C99 compliant systems
-//#include <kdefakes.h> // trunc for not C99 compliant systems
-
-#include <QPainter>
-#include <QScrollBar>
-#include <QPaintEvent>
-
-#include <algorithm>
-
 #include "qcategorydrawer.h"
 #include "qcategorizedsortfilterproxymodel.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+#include <QScrollBar>
+
+#include <algorithm>
 
 //BEGIN: Private part
 

--- a/src/qcategorizedview/qcategorydrawer.cpp
+++ b/src/qcategorizedview/qcategorydrawer.cpp
@@ -20,14 +20,12 @@
   */
 
 #include "qcategorydrawer.h"
+#include "qcategorizedview.h"
+#include "qcategorizedsortfilterproxymodel.h"
 
 #include <QPainter>
 #include <QStyleOption>
 #include <QApplication>
-
-//#include <kiconloader.h>
-#include <qcategorizedview.h>
-#include <qcategorizedsortfilterproxymodel.h>
 
 #define HORIZONTAL_HINT 3
 


### PR DESCRIPTION
These are remnants of code from probably many years ago and the headers served no purpose other than slowing down compilation.

In some cases I also reorganized header order to be:
```
#include "local.h"
..
#include <LXQt/...>
..
#include <Qt headers>
```

Testing on my machine after re-running `cmake ..`, compilation speeds increased 6.8%:
```
Before:
time make -j6
real    0m44.706s
user    3m47.929s
sys     0m23.574s
====================
After:
real    0m41.635s
user    3m38.059s
sys     0m22.413s
```