### PR TITLE
Fixed "Drag lock" box

### DIFF
--- a/lxqt-config-input/touchpadconfig.cpp
+++ b/lxqt-config-input/touchpadconfig.cpp
@@ -52,27 +52,28 @@ TouchpadConfig::TouchpadConfig(LXQt::Settings* _settings, QWidget* parent):
     connect(ui.tappingEnabledCheckBox, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.naturalScrollingEnabledCheckBox, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.disableWhileTypingCheckBox, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
-    connect(ui.tapToDragEnabledCheckBox, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
+    connect(ui.tapToDragEnabledCheckBox, &QGroupBox::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.dragLockEnabledCheckBox, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.accelSpeedDoubleSpinBox, &QDoubleSpinBox::valueChanged, this, &TouchpadConfig::settingsChanged);
     connect(ui.noScrollingRadioButton, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.twoFingerScrollingRadioButton, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.edgeScrollingRadioButton, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
     connect(ui.buttonScrollingRadioButton, &QAbstractButton::clicked, this, &TouchpadConfig::settingsChanged);
-    connect(ui.tapToDragEnabledCheckBox, &QCheckBox::toggled,ui.dragLockEnabledCheckBox, &QCheckBox::setEnabled);
-    ui.dragLockEnabledCheckBox->setEnabled(ui.tapToDragEnabledCheckBox->isChecked());
 }
 
 TouchpadConfig::~TouchpadConfig()
 {
 }
 
-void TouchpadConfig::initFeatureControl(QCheckBox* control, int featureEnabled)
+void TouchpadConfig::initFeatureControl(QWidget* control, int featureEnabled)
 {
     if (featureEnabled >= 0)
     {
         control->setEnabled(true);
-        control->setCheckState(featureEnabled ? Qt::Checked : Qt::Unchecked);
+        if (auto cb = qobject_cast<QCheckBox*>(control))
+            cb->setChecked(featureEnabled ? true : false);
+        else if (auto gb = qobject_cast<QGroupBox*>(control))
+            gb->setChecked(featureEnabled ? true : false);
     }
     else
     {
@@ -92,7 +93,7 @@ void TouchpadConfig::initControls()
     initFeatureControl(ui.naturalScrollingEnabledCheckBox, device.naturalScrollingEnabled());
     initFeatureControl(ui.disableWhileTypingCheckBox, device.disableWhileTypingEnabled());
     initFeatureControl(ui.tapToDragEnabledCheckBox, device.tapToDragEnabled());
-    ui.dragLockEnabledCheckBox->setEnabled(ui.tapToDragEnabledCheckBox->isChecked());
+    initFeatureControl(ui.dragLockEnabledCheckBox, device.dragLockEnabled());
 
     auto ok = device.xinputDriverSupported();
     if (!ok) {
@@ -198,35 +199,35 @@ void TouchpadConfig::applyConfig()
     bool acceptSetting = false;
     TouchpadDevice& device = devices[curDevice];
 
-    bool enable = ui.tappingEnabledCheckBox->checkState() == Qt::Checked;
+    bool enable = ui.tappingEnabledCheckBox->isChecked();
     if (enable != (device.tappingEnabled() > 0))
     {
         device.setTappingEnabled(enable);
         acceptSetting = true;
     }
 
-    enable = ui.naturalScrollingEnabledCheckBox->checkState() == Qt::Checked;
+    enable = ui.naturalScrollingEnabledCheckBox->isChecked();
     if (enable != (device.naturalScrollingEnabled() > 0))
     {
         device.setNaturalScrollingEnabled(enable);
         acceptSetting = true;
     }
 
-    enable = ui.disableWhileTypingCheckBox->checkState() == Qt::Checked;
+    enable = ui.disableWhileTypingCheckBox->isChecked();
     if (enable != (device.disableWhileTypingEnabled() > 0))
     {
         device.setDisableWhileTypingEnabled(enable);
         acceptSetting = true;
     }
 
-    enable = ui.tapToDragEnabledCheckBox->checkState() == Qt::Checked;
+    enable = ui.tapToDragEnabledCheckBox->isChecked();
     if (enable != (device.tapToDragEnabled() > 0))
     {
         device.setTapToDragEnabled(enable);
         acceptSetting = true;
     }
 
-    enable = ui.dragLockEnabledCheckBox->checkState() == Qt::Checked;
+    enable = ui.dragLockEnabledCheckBox->isChecked();
     if (enable != (device.dragLockEnabled() > 0))
     {
         device.setDragLockEnabled(enable);

--- a/lxqt-config-input/touchpadconfig.h
+++ b/lxqt-config-input/touchpadconfig.h
@@ -48,7 +48,7 @@ Q_SIGNALS:
 
 private:
     void initControls();
-    void initFeatureControl(QCheckBox* control, int featureEnabled);
+    void initFeatureControl(QWidget* control, int featureEnabled);
 
 private:
     LXQt::Settings* settings;

--- a/lxqt-config-input/touchpadconfig.ui
+++ b/lxqt-config-input/touchpadconfig.ui
@@ -76,51 +76,23 @@
     </widget>
    </item>
    <item row="6" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="tapToDragEnabledCheckBox">
-       <property name="text">
-        <string>Tap and drag</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>5</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="dragLockEnabledCheckBox">
-       <property name="text">
-        <string>Drag lock</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>5</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QGroupBox" name="tapToDragEnabledCheckBox">
+     <property name="title">
+      <string>Tap and drag</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="dragLockEnabledCheckBox">
+        <property name="text">
+         <string>Drag lock</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="7" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
Also,

 * Simplified the code by using `isChecked()` instead of `checkState()` and removing extra connections and state settings.
 * Made using of "Drag lock" dependent on "Tap and drag".