### PR TITLE
Don't show LXDE settings

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -88,7 +88,7 @@ public:
     {
         QString menuFile = XdgMenu::getMenuFileName(QStringLiteral("config.menu"));
         XdgMenu xdgMenu;
-        xdgMenu.setEnvironments(QStringList() << QStringLiteral("X-LXQT") << QStringLiteral("LXQt") << QStringLiteral("LXDE"));
+        xdgMenu.setEnvironments(QStringList() << QStringLiteral("X-LXQT") << QStringLiteral("LXQt"));
         bool res = xdgMenu.read(menuFile);
         if (!res)
         {


### PR DESCRIPTION
Without this, LXDE's Desktop Session Settings tool is shown in the Configuration Center, which has no effect in LXQt.