### PR TITLE
update for kscreen 6.6

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
+++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
@@ -193,7 +193,7 @@ void MonitorSettingsDialog::saveConfiguration(KScreen::ConfigPtr config)
         monitor.connected = output->isConnected();
         if ( output->isConnected() ) {
             monitor.enabled = output->isEnabled();
-            monitor.primary = output->isPrimary();
+            monitor.primary = (config->primaryOutput() == output);
             monitor.xPos = output->pos().x();
             monitor.yPos = output->pos().y();
             monitor.currentMode = output->currentModeId();

--- a/lxqt-config-monitor/monitorwidget.cpp
+++ b/lxqt-config-monitor/monitorwidget.cpp
@@ -146,7 +146,7 @@ MonitorWidget::MonitorWidget(KScreen::OutputPtr output, KScreen::ConfigPtr confi
     ui.yPosSpinBox->setValue(output->pos().y());
 
     // Behavior chooser
-    if (output->isPrimary())
+    if (config->primaryOutput() == output)
         ui.behaviorCombo->setCurrentIndex(PrimaryDisplay);
     else
         ui.behaviorCombo->setCurrentIndex(ExtendDisplay);


### PR DESCRIPTION
the kscreen API removed the isPrimary() method from KScreen::Output in 6.6, Port to new method Config::PrimaryOutput()