### PR TITLE
Tidy applicationchooser.ui

### DIFF
--- a/lxqt-config-file-associations/applicationchooser.ui
+++ b/lxqt-config-file-associations/applicationchooser.ui
@@ -35,7 +35,7 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
+      <item row="0" column="0">
        <widget class="QLabel" name="mimetypeIconLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -54,7 +54,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="QLabel" name="mimetypeLabel">
         <property name="text">
          <string notr="true">Mimetype</string>

--- a/lxqt-config-file-associations/applicationchooser.ui
+++ b/lxqt-config-file-associations/applicationchooser.ui
@@ -15,6 +15,18 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="headingLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Pick an application for:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QFrame" name="frame_2">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -23,30 +35,6 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="headingLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Pick an application for:</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="mimetypeIconLabel">
         <property name="sizePolicy">


### PR DESCRIPTION
- Tidy the layout and remove some redundant tags

Before: <img width="393" height="450" alt="before" src="https://github.com/user-attachments/assets/e96b7a89-c861-48fd-ba61-84e1734a6aa4" />

After: <img width="393" height="450" alt="after" src="https://github.com/user-attachments/assets/46ec73b3-8ee1-4467-9e56-99da31772907" />

I saw another layout issue when there is no MIME icon available, but didn't address it here.