### PR TITLE
cmake maint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ find_package(Qt6Xml ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt-menu-data ${LXQT_MINIMUM_VERSION} REQUIRED)
 
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6GuiPrivate ${QT_MINIMUM_VERSION} REQUIRED)
+endif()
+
 include(LXQtPreventInSourceBuilds)
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
 

--- a/liblxqt-config-cursor/CMakeLists.txt
+++ b/liblxqt-config-cursor/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(X11 REQUIRED)
 find_package(XCB REQUIRED XCB)
+find_package(ZLIB REQUIRED)
+
 include_directories(${XCB_INCLUDE_DIRS})
 link_libraries(${XCB_LIBRARIES})
 
@@ -35,8 +37,6 @@ set(lxqt-config-cursor_UIS
     selectwnd.ui
     warninglabel.ui
 )
-
-find_package(ZLIB REQUIRED)
 
 # Translations **********************************
 lxqt_translate_ts(QM_FILES

--- a/liblxqt-config-cursor/CMakeLists.txt
+++ b/liblxqt-config-cursor/CMakeLists.txt
@@ -1,12 +1,8 @@
 find_package(X11 REQUIRED)
-find_package(XCB REQUIRED XCB)
+find_package(XCB REQUIRED COMPONENTS XCB)
 find_package(ZLIB REQUIRED)
 
-include_directories(${XCB_INCLUDE_DIRS})
-link_libraries(${XCB_LIBRARIES})
-
 include_directories (
-    ${X11_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/xcr
 )
 
@@ -67,11 +63,12 @@ add_library(lxqt-config-cursor
 target_link_libraries(lxqt-config-cursor
     Qt6::DBus
     Qt6::Xml
-    ${X11_X11_LIB}
-    ${X11_Xcursor_LIB}
+    X11::X11
+    X11::Xcursor
+    X11::Xfixes
+    ZLIB::ZLIB
+    XCB::XCB
     lxqt
-    ${ZLIB_LIBRARY}
-    ${X11_Xfixes_LIB}
 )
 # not needed probably ${X11_Xfixes_LIB})
 

--- a/liblxqt-config-cursor/CMakeLists.txt
+++ b/liblxqt-config-cursor/CMakeLists.txt
@@ -2,10 +2,6 @@ find_package(X11 REQUIRED)
 find_package(XCB REQUIRED COMPONENTS XCB)
 find_package(ZLIB REQUIRED)
 
-include_directories (
-    ${CMAKE_CURRENT_SOURCE_DIR}/xcr
-)
-
 set(lxqt-config-cursor_HDRS
     thememodel.h
     previewwidget.h
@@ -58,6 +54,11 @@ add_library(lxqt-config-cursor
         ${DESKTOP_FILES}
         ${QM_FILES}
         ${lxqt-config-cursor_QM_LOADER}
+)
+
+target_include_directories(lxqt-config-cursor
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/xcr
 )
 
 target_link_libraries(lxqt-config-cursor

--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -38,8 +38,6 @@ set(UI_FILES
     gtkconfig.ui
 )
 
-set(QRC_FILES "")
-
 set(LIBRARIES
     lxqt
 )
@@ -65,8 +63,6 @@ lxqt_translate_desktop(DESKTOP_FILES SOURCES lxqt-config-appearance.desktop.in U
 
 add_executable(lxqt-config-appearance
     ${CPP_FILES}
-    ${RESOURCES}
-    ${QRC_FILES}
     ${QM_FILES}
     ${QM_LOADER}
     ${DESKTOP_FILES}

--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -38,11 +38,6 @@ set(UI_FILES
     gtkconfig.ui
 )
 
-set(LIBRARIES
-    lxqt
-)
-
-
 # Translations **********************************
 lxqt_translate_ts(QM_FILES
         UPDATE_TRANSLATIONS ${UPDATE_TRANSLATIONS}
@@ -71,7 +66,7 @@ add_executable(lxqt-config-appearance
 target_link_libraries(lxqt-config-appearance
     Qt6::Widgets
     Qt6::Xml
-    ${LIBRARIES}
+    lxqt
     lxqt-config-cursor
 )
 

--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -35,7 +35,8 @@ set(UI_FILES
 
 # Translations **********************************
 lxqt_translate_ts(QM_FILES
-        UPDATE_TRANSLATIONS ${UPDATE_TRANSLATIONS}
+    UPDATE_TRANSLATIONS
+        ${UPDATE_TRANSLATIONS}
     SOURCES
         ${H_FILES}
         ${CPP_FILES}

--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -1,5 +1,4 @@
 include_directories(
-    ${Qt6Gui_PRIVATE_INCLUDE_DIRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
 )
 
@@ -64,10 +63,13 @@ add_executable(lxqt-config-appearance
 )
 
 target_link_libraries(lxqt-config-appearance
-    Qt6::Widgets
-    Qt6::Xml
-    lxqt
-    lxqt-config-cursor
+    PRIVATE
+        Qt6::GuiPrivate
+    PUBLIC
+        Qt6::Widgets
+        Qt6::Xml
+        lxqt
+        lxqt-config-cursor
 )
 
 set_target_properties("lxqt-config-appearance"

--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -1,7 +1,3 @@
-include_directories(
-    "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
-)
-
 set(H_FILES
     iconthemeinfo.h
 )
@@ -60,6 +56,11 @@ add_executable(lxqt-config-appearance
     ${QM_FILES}
     ${QM_LOADER}
     ${DESKTOP_FILES}
+)
+
+target_include_directories(lxqt-config-appearance
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
 )
 
 target_link_libraries(lxqt-config-appearance

--- a/lxqt-config-brightness/CMakeLists.txt
+++ b/lxqt-config-brightness/CMakeLists.txt
@@ -50,8 +50,9 @@ target_link_libraries(lxqt-config-brightness
     lxqt
 )
 
-add_definitions(
-    -DICON_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/48x48/apps"
+target_compile_definitions(lxqt-config-brightness
+    PRIVATE
+        -DICON_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/48x48/apps"
 )
 
 install(TARGETS lxqt-config-brightness RUNTIME DESTINATION bin)

--- a/lxqt-config-brightness/CMakeLists.txt
+++ b/lxqt-config-brightness/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories (
 set(H_FILES
     brightnesswatcher.h
     brightnesssettings.h
-	xrandrbrightness.h
+    xrandrbrightness.h
     monitorinfo.h
     outputwidget.h
 )
@@ -28,7 +28,6 @@ set(UI_FILES
 
 qt6_wrap_ui(UI_HEADERS ${UI_FILES})
 
-
 # Translations **********************************
 lxqt_translate_ts(QM_FILES
     UPDATE_TRANSLATIONS
@@ -46,11 +45,9 @@ lxqt_translate_ts(QM_FILES
 lxqt_app_translation_loader(QM_LOADER lxqt-config-brightness)
 lxqt_translate_desktop(DESKTOP_FILES SOURCES "resources/lxqt-config-brightness.desktop.in" USE_YAML)
 
-
 add_executable(lxqt-config-brightness ${CPP_FILES} ${UI_FILES} ${QM_FILES} ${DESKTOP_FILES} ${QM_LOADER})
 
-target_link_libraries(
-    lxqt-config-brightness
+target_link_libraries(lxqt-config-brightness
     Qt6::Widgets
     ${XCB_LIBRARIES}
     lxqt
@@ -59,7 +56,6 @@ target_link_libraries(
 add_definitions(
     -DICON_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/48x48/apps"
 )
-
 
 install(TARGETS lxqt-config-brightness RUNTIME DESTINATION bin)
 install(FILES ${DESKTOP_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)

--- a/lxqt-config-brightness/CMakeLists.txt
+++ b/lxqt-config-brightness/CMakeLists.txt
@@ -1,8 +1,4 @@
-find_package(XCB REQUIRED XCB RANDR)
-
-include_directories (
-    ${XCB_INCLUDE_DIRS}
-)
+find_package(XCB REQUIRED COMPONENTS XCB RANDR)
 
 set(H_FILES
     brightnesswatcher.h
@@ -49,7 +45,8 @@ add_executable(lxqt-config-brightness ${CPP_FILES} ${UI_FILES} ${QM_FILES} ${DES
 
 target_link_libraries(lxqt-config-brightness
     Qt6::Widgets
-    ${XCB_LIBRARIES}
+    XCB::XCB
+    XCB::RANDR
     lxqt
 )
 

--- a/lxqt-config-brightness/CMakeLists.txt
+++ b/lxqt-config-brightness/CMakeLists.txt
@@ -1,8 +1,4 @@
-find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(XCB REQUIRED XCB RANDR)
-
-set(QTX_LIBRARIES Qt6::Widgets)
-
 
 include_directories (
     ${XCB_INCLUDE_DIRS}
@@ -55,7 +51,7 @@ add_executable(lxqt-config-brightness ${CPP_FILES} ${UI_FILES} ${QM_FILES} ${DES
 
 target_link_libraries(
     lxqt-config-brightness
-    ${QTX_LIBRARIES}
+    Qt6::Widgets
     ${XCB_LIBRARIES}
     lxqt
 )

--- a/lxqt-config-file-associations/CMakeLists.txt
+++ b/lxqt-config-file-associations/CMakeLists.txt
@@ -22,10 +22,6 @@ set(UI_FILES
     applicationchooser.ui
 )
 
-set(LIBRARIES
-    lxqt
-)
-
 # Translations **********************************
 lxqt_translate_ts(QM_FILES
     UPDATE_TRANSLATIONS
@@ -56,7 +52,7 @@ target_link_libraries(lxqt-config-file-associations
     Qt6::Xml
     Qt6::DBus
     Qt6::Widgets
-    ${LIBRARIES}
+    lxqt
 )
 
 install(TARGETS

--- a/lxqt-config-file-associations/CMakeLists.txt
+++ b/lxqt-config-file-associations/CMakeLists.txt
@@ -22,8 +22,6 @@ set(UI_FILES
     applicationchooser.ui
 )
 
-set(QRC_FILES "")
-
 set(LIBRARIES
     lxqt
 )
@@ -49,8 +47,6 @@ lxqt_translate_desktop(DESKTOP_FILES SOURCES lxqt-config-file-associations.deskt
 
 add_executable(lxqt-config-file-associations
     ${CPP_FILES}
-    ${RESOURCES}
-    ${QRC_FILES}
     ${QM_FILES}
     ${QM_LOADER}
     ${DESKTOP_FILES}

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -3,7 +3,6 @@ find_package(X11 REQUIRED)
 if (WITH_TOUCHPAD)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(XORG_LIBINPUT REQUIRED xorg-libinput)
-    pkg_check_modules(XORG_XI REQUIRED xi)
     pkg_check_modules(LIBUDEV REQUIRED libudev)
 endif ()
 

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -6,25 +6,12 @@ if (WITH_TOUCHPAD)
     pkg_check_modules(LIBUDEV REQUIRED libudev)
 endif ()
 
-set(lxqt-config-input_INCS
-    "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
-)
-
 if (WITH_TOUCHPAD)
     add_definitions(
         "-DWITH_TOUCHPAD=\"ON\""
     )
 
-    set(lxqt-config-input_INCS
-        ${lxqt-config-input_INCS}
-        ${XORG_LIBINPUT_INCLUDE_DIRS}
-    )
 endif ()
-
-include_directories(
-    ${lxqt-config-input_INCS}
-)
-
 set(lxqt-config-input_HDRS
     keyboardconfig.h
     mouseconfig.h
@@ -103,23 +90,19 @@ add_executable(lxqt-config-input
     ${QM_LOADER}
 )
 
-set(lxqt-config-input_TLBS
+target_include_directories(lxqt-config-input
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
+        "$<$<BOOL:${WITH_TOUCHPAD}>:${XORG_LIBINPUT_INCLUDE_DIRS}>"
+)
+
+target_link_libraries(lxqt-config-input
     Qt6::Widgets
     X11::X11
     lxqt
     lxqt-config-cursor
-)
-
-if (WITH_TOUCHPAD)
-    set(lxqt-config-input_TLBS
-        ${lxqt-config-input_TLBS}
-        ${X11_Xinput_LIB}
-        udev
-    )
-endif ()
-
-target_link_libraries(lxqt-config-input
-    ${lxqt-config-input_TLBS}
+    $<$<BOOL:${WITH_TOUCHPAD}>:${X11_Xinput_LIB}>
+    $<$<BOOL:${WITH_TOUCHPAD}>:udev>
 )
 
 set_target_properties(lxqt-config-input

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -8,7 +8,6 @@ if (WITH_TOUCHPAD)
 endif ()
 
 set(lxqt-config-input_INCS
-    ${X11_INCLUDE_DIR}
     "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
 )
 
@@ -107,7 +106,7 @@ add_executable(lxqt-config-input
 
 set(lxqt-config-input_TLBS
     Qt6::Widgets
-    ${X11_LIBRARIES}
+    X11::X11
     lxqt
     lxqt-config-cursor
 )

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -6,12 +6,6 @@ if (WITH_TOUCHPAD)
     pkg_check_modules(LIBUDEV REQUIRED libudev)
 endif ()
 
-if (WITH_TOUCHPAD)
-    add_definitions(
-        "-DWITH_TOUCHPAD=\"ON\""
-    )
-
-endif ()
 set(lxqt-config-input_HDRS
     keyboardconfig.h
     mouseconfig.h
@@ -79,15 +73,17 @@ lxqt_translate_desktop(DESKTOP_FILES
 
 #************************************************
 
-add_definitions(
-  -DPACKAGE_DATA_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/lxqt-config-input"
-)
-
 add_executable(lxqt-config-input
     ${lxqt-config-input_SRCS}
     ${DESKTOP_FILES}
     ${QM_FILES}
     ${QM_LOADER}
+)
+
+target_compile_definitions(lxqt-config-input
+    PRIVATE
+        "$<$<BOOL:${WITH_TOUCHPAD}>:-DWITH_TOUCHPAD=ON>"
+        "-DPACKAGE_DATA_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}/lxqt-config-input\""
 )
 
 target_include_directories(lxqt-config-input

--- a/lxqt-config-locale/CMakeLists.txt
+++ b/lxqt-config-locale/CMakeLists.txt
@@ -36,8 +36,6 @@ lxqt_translate_desktop(DESKTOP_FILES SOURCES lxqt-config-locale.desktop.in USE_Y
 add_executable(lxqt-config-locale
     ${CPP_FILES}
     ${COMBO_HEADER}
-    ${RESOURCES}
-    ${QRC_SOURCES}
     ${QM_FILES}
     ${DESKTOP_FILES}
     ${QM_LOADER}

--- a/lxqt-config-monitor/CMakeLists.txt
+++ b/lxqt-config-monitor/CMakeLists.txt
@@ -70,8 +70,6 @@ lxqt_translate_desktop(DESKTOP_FILES
 
 add_executable(lxqt-config-monitor
     ${SOURCES}
-    ${RESOURCES}
-    ${QRC_SOURCES}
     ${DESKTOP_FILES}
     ${QM_FILES}
     ${QM_LOADER}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-project(lxqt-config)
 add_subdirectory(qcategorizedview)
 
 include_directories (
@@ -28,11 +27,13 @@ lxqt_translate_ts(QM_FILES
         ${lxqt-config_HDRS}
         ${lxqt-config_SRCS}
         ${lxqt-config_UIS}
+    TEMPLATE
+        lxqt-config
     INSTALL_DIR
         "${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}"
 )
 
-lxqt_app_translation_loader(QM_LOADER ${PROJECT_NAME})
+lxqt_app_translation_loader(QM_LOADER lxqt-config)
 lxqt_translate_desktop(DESKTOP_FILES SOURCES lxqt-config.desktop.in USE_YAML)
 
 #************************************************

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,5 @@
 add_subdirectory(qcategorizedview)
 
-include_directories (
-    "${CMAKE_CURRENT_SOURCE_DIR}/qcategorizedview"
-)
-
 set(lxqt-config_SRCS
     main.cpp
     mainwindow.cpp
@@ -40,6 +36,11 @@ add_executable(lxqt-config
     ${DESKTOP_FILES}
     ${QM_FILES}
     ${QM_LOADER}
+)
+
+target_include_directories(lxqt-config
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/qcategorizedview"
 )
 
 target_link_libraries(lxqt-config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,14 +44,13 @@ target_include_directories(lxqt-config
 )
 
 target_link_libraries(lxqt-config
-    Qt6::Widgets
-    Qt6::Xml
-    lxqt
+    PUBLIC
+        Qt6::Widgets
+        Qt6::Xml
+        lxqt
+    PRIVATE
+        qcategorizedview
 )
-
-# helper static lib
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/qcategorizedview)
-target_link_libraries(lxqt-config qcategorizedview)
 
 install(TARGETS
     lxqt-config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@ include_directories (
     "${CMAKE_CURRENT_SOURCE_DIR}/qcategorizedview"
 )
 
-set(lxqt-config_HDRS "")
-
 set(lxqt-config_SRCS
     main.cpp
     mainwindow.cpp
@@ -24,7 +22,6 @@ lxqt_translate_ts(QM_FILES
     UPDATE_TRANSLATIONS
         ${UPDATE_TRANSLATIONS}
     SOURCES
-        ${lxqt-config_HDRS}
         ${lxqt-config_SRCS}
         ${lxqt-config_UIS}
     TEMPLATE


### PR DESCRIPTION
- **liblxqt-config-cursor: Pack find_package stuff**
- **liblxqt-config-cursor: Use Targets**
- **liblxqt-config-cursor: Better handling of include_directories**
- **lxqt-config-appearance: Drop unused variables**
- **lxqt-config-appearance: Simplify libllxqt use**
- **lxqt-config-appearance: Better Qt6GuiPrivate handling**
- **lxqt-config-appearance: Improve include directories handing**
- **lxqt-config-appearance: Fix indentation**
- **lxqt-config-brightness: Simplify Qt6Widgets use**
- **lxqt-config-brightness: Fix indentation and empty lines**
- **lxqt-config-brightness: Use Targets**
- **lxqt-config-brightness: Use per target compile definitions**
- **lxqt-config-file-associations: Don't use empty variables**
- **lxqt-config-file-associations: Simplify liblxqt use**
- **lxqt-config-locale: Don't use empty variables**
- **lxqt-config-monitor: Don't use empty variables**
- **lxqt-config/src: Drop nested project**
- **lxqt-config/src: Clean empty variables**
- **lxqt-config/src: Use per target include directories**
- **lxqt-config/src: Simplify qcategorizedview use**
- **lxqt-config-input: Use X11 Targets**
- **lxqt-config-input: Don't check for not used packages**
- **lxqt-config-input: Update link libs and include dirs**
- **lxqt-config-input: Pack compile definitions**
