### PR TITLE
Brightness: Add Qt icons fallback to head label

### DIFF
--- a/lxqt-config-brightness/brightnesssettings.cpp
+++ b/lxqt-config-brightness/brightnesssettings.cpp
@@ -34,7 +34,8 @@ BrightnessSettings::BrightnessSettings(QWidget *parent):QDialog(parent)
     mMonitorsInitial = mBrightness->getMonitorsInfo();
     mBacklight = new LXQt::Backlight(this);
 
-    ui->headIconLabel->setPixmap(QIcon::fromTheme(QStringLiteral("display-brightness-symbolic")).pixmap(32, 32));
+    ui->headIconLabel->setPixmap(QIcon::fromTheme(QStringLiteral("video-display-brightness"),
+                                 QIcon::fromTheme(QStringLiteral("video-display"))).pixmap(32, 32));
 
     ui->backlightSlider->setEnabled(mBacklight->isBacklightAvailable() || mBacklight->isBacklightOff());
     ui->backlightGroupBox->setEnabled(mBacklight->isBacklightAvailable() || mBacklight->isBacklightOff());


### PR DESCRIPTION
The icon besides the header text did not display with Breeze or Breeze Dark icons, only with GTK ones → Adwaita, GNOME.

I'm certainly open to finding more appropriate icons - "-symbolic" should generally be avoided.