### PR TITLE
Remove redundant/deprecated Qt headers

### DIFF
--- a/liblxqt-config-cursor/main.cpp
+++ b/liblxqt-config-cursor/main.cpp
@@ -7,8 +7,8 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
-//#include <QtCore>
-#include <QDebug>
+
+// #include <QDebug>
 
 #include <XdgIcon>
 #include <LXQt/Settings>
@@ -20,16 +20,10 @@
 #include <QImage>
 #include <QString>
 #include <QStringList>
-#include <QTextCodec>
 #include <QTextStream>
 
-
-///////////////////////////////////////////////////////////////////////////////
 int main (int argc, char *argv[])
 {
-    //QTextCodec::setCodecForCStrings(QTextCodec::codecForName("koi8-r"));
-    //QTextCodec::setCodecForLocale(QTextCodec::codecForName("koi8-r"));
-
     LXQt::Application app(argc, argv);
 
     TRANSLATE_APP;

--- a/lxqt-config-appearance/colorLabel.h
+++ b/lxqt-config-appearance/colorLabel.h
@@ -28,7 +28,6 @@
 
 #include <QLabel>
 #include <QWidget>
-#include <Qt>
 
 class ColorLabel : public QLabel {
     Q_OBJECT

--- a/lxqt-config-input/keyboardlayoutconfig.h
+++ b/lxqt-config-input/keyboardlayoutconfig.h
@@ -21,7 +21,6 @@
 #ifndef KEYBOARDLAYOUTCONFIG_H
 #define KEYBOARDLAYOUTCONFIG_H
 
-#include <QtCore/QtGlobal>
 #ifdef Q_OS_LINUX
 #define XKBD_BASELIST_PATH "/usr/share/X11/xkb/rules/base.lst"
 #elif defined(Q_OS_FREEBSD)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,10 +27,8 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-
-
 #include "ui_mainwindow.h"
-#include <QtXml/QDomElement>
+#include <QDomElement>
 
 class QCategorizedSortFilterProxyModel;
 
@@ -68,6 +66,5 @@ private slots:
 };
 
 } // namespace
-
 
 #endif


### PR DESCRIPTION
- `<Qt>`/`<QtCore>`/`<QtCore/QtGlobal>` removal (redundant)
- `<QTextCodec>` wasn't used, and is a Qt 5 Compat module