### PR TITLE
Substitute all <QtCore> headers

### DIFF
--- a/liblxqt-config-cursor/xcr/xcrimg.h
+++ b/liblxqt-config-cursor/xcr/xcrimg.h
@@ -10,7 +10,12 @@
 #ifndef XCRIMG_H
 #define XCRIMG_H
 
-#include <QtCore>
+#include <QFile>
+#include <QDir>
+#include <QString>
+#include <QByteArray>
+#include <QImage>
+#include <QList>
 #include <QCursor>
 #include <QPixmap>
 

--- a/liblxqt-config-cursor/xcr/xcrtheme.cpp
+++ b/liblxqt-config-cursor/xcr/xcrtheme.cpp
@@ -7,8 +7,8 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #include <QDebug>
-//#include <QtCore>
 
 #include "xcrtheme.h"
 

--- a/liblxqt-config-cursor/xcr/xcrtheme.h
+++ b/liblxqt-config-cursor/xcr/xcrtheme.h
@@ -10,7 +10,11 @@
 #ifndef XCRTHEME_H
 #define XCRTHEME_H
 
-#include <QtCore>
+#include <QString>
+#include <QStringList>
+#include <QProcess>
+#include <QList>
+#include <QDir>
 #include <QCursor>
 #include <QPixmap>
 

--- a/liblxqt-config-cursor/xcr/xcrthemefx.cpp
+++ b/liblxqt-config-cursor/xcr/xcrthemefx.cpp
@@ -7,8 +7,8 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #include <QDebug>
-//#include <QtCore>
 
 #include "xcrthemefx.h"
 

--- a/liblxqt-config-cursor/xcr/xcrthemefx.h
+++ b/liblxqt-config-cursor/xcr/xcrthemefx.h
@@ -10,7 +10,8 @@
 #ifndef XCRTHEMEFX_H
 #define XCRTHEMEFX_H
 
-#include <QtCore>
+#include <QString>
+#include <QList>
 #include <QCursor>
 #include <QPixmap>
 

--- a/liblxqt-config-cursor/xcr/xcrthemexp.cpp
+++ b/liblxqt-config-cursor/xcr/xcrthemexp.cpp
@@ -7,8 +7,8 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #include <QDebug>
-//#include <QtCore>
 
 #include "xcrthemexp.h"
 

--- a/liblxqt-config-cursor/xcr/xcrthemexp.h
+++ b/liblxqt-config-cursor/xcr/xcrthemexp.h
@@ -10,7 +10,8 @@
 #ifndef XCRTHEMEXP_H
 #define XCRTHEMEXP_H
 
-#include <QtCore>
+#include <QString>
+#include <QDir>
 #include <QCursor>
 #include <QPixmap>
 

--- a/liblxqt-config-cursor/xcr/xcrxcur.cpp
+++ b/liblxqt-config-cursor/xcr/xcrxcur.cpp
@@ -7,8 +7,8 @@
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://sam.zoy.org/wtfpl/COPYING for more details.
  */
+
 #include <QDebug>
-//#include <QtCore>
 
 #include "xcrxcur.h"
 
@@ -16,7 +16,6 @@
 #include <QStringList>
 #include <QStyle>
 #include <QTextStream>
-
 
 #include <X11/Xlib.h>
 #include <X11/Xcursor/Xcursor.h>

--- a/liblxqt-config-cursor/xcr/xcrxcur.h
+++ b/liblxqt-config-cursor/xcr/xcrxcur.h
@@ -10,7 +10,8 @@
 #ifndef XCRXCUR_H
 #define XCRXCUR_H
 
-#include <QtCore>
+#include <QString>
+#include <QDir>
 #include <QCursor>
 #include <QPixmap>
 


### PR DESCRIPTION
`<QtCore>` pulled in 30+ headers serving to slow compilation. I'm unsure the status of `<QtGlobal>` since Qt 6.5, but this PR doesn't touch that.
