### PR TITLE
🖱️🎨 Fix GTK theme reset when applying mouse/cursor settings

### DIFF
--- a/lxqt-config-appearance/configothertoolkits.cpp
+++ b/lxqt-config-appearance/configothertoolkits.cpp
@@ -230,8 +230,11 @@ void ConfigOtherToolKits::setXSettingsConfig()
 void ConfigOtherToolKits::setGsettingsConfig(QString version, QString theme)
 {
     updateConfigFromSettings();
-    if(!theme.isEmpty())
-        mConfig.styleTheme = theme;
+    // Callers that only sync cursor/icon/font (e.g. lxqt-config-input) omit theme.
+    // Keep the existing GTK theme instead of writing an empty name.
+    if(theme.isEmpty())
+        theme = getGTKThemeFromRCFile(version);
+    mConfig.styleTheme = theme;
     QString commands;
     if(version == QLatin1String("3.0"))
         commands = getConfig(GTK3_GSETTINGS, ConfigOtherToolKits::GTK3GSETTINGS);
@@ -250,8 +253,11 @@ void ConfigOtherToolKits::setGsettingsConfig(QString version, QString theme)
 void ConfigOtherToolKits::setGTKConfig(QString version, QString theme)
 {
     updateConfigFromSettings();
-    if(!theme.isEmpty())
-        mConfig.styleTheme = theme;
+    // Callers that only sync cursor/icon/font (e.g. lxqt-config-input) omit theme.
+    // Keep the existing GTK theme instead of writing an empty name.
+    if(theme.isEmpty())
+        theme = getGTKThemeFromRCFile(version);
+    mConfig.styleTheme = theme;
     backupGTKSettings(version);
     QString gtkrcPath = getGTKConfigPath(version);
     if(version == QLatin1String("2.0"))


### PR DESCRIPTION
Applying changes in **Keyboard and Mouse Settings** 🖱️ no longer wipes the GTK widget theme 🎨

- 🐛 **Bug:** With *Set GTK themes* enabled, **Apply** in `lxqt-config-input` rewrote `~/.gtkrc-2.0` and `~/.config/gtk-3.0/settings.ini` with an **empty** `gtk-theme-name`
- 💥 **Symptom:** Appearance then showed the first combo items
- ✅ **Fix:** If no theme is passed, keep the one already in the rc files via `getGTKThemeFromRCFile()` — same idea `setConfig()` already uses in appearance 🧠
- Same fallback in `setGsettingsConfig()` so Wayland does not clobber the theme either

Closes https://github.com/lxqt/lxqt-config/issues/1220